### PR TITLE
fix(ci): disable cargo package verification for release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -25,6 +25,9 @@ semver_check = false
 # Don't publish to crates.io
 publish = false
 
+# Skip cargo package verification (internal deps don't have version specs)
+cargo_package_verify = false
+
 [changelog]
 header = """# Changelog
 


### PR DESCRIPTION
Internal workspace dependencies use path-only references without versions. Since we're not publishing to crates.io (git_only = true), cargo package verification is not needed and causes false failures.