### PR TITLE
fix(ci): use correct publish_no_verify field name

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -26,7 +26,7 @@ semver_check = false
 publish = false
 
 # Skip cargo package verification (internal deps don't have version specs)
-cargo_package_verify = false
+publish_no_verify = true
 
 [changelog]
 header = """# Changelog


### PR DESCRIPTION
The field is publish_no_verify (not cargo_package_verify). This adds --no-verify flag to cargo publish to skip package verification, which fails due to internal deps using path-only references.