### PR TITLE
chore: reset versions to 0.0.1 for fresh release-plz start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,7 +2508,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcpmux"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-core"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2565,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-gateway"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-mcp"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-storage"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/mcpmux/mcpmux"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcpmux/desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "McpMux",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "identifier": "com.mcpmux.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev:web",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcpmux",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmux/ui",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "private": true,
   "description": "Shared UI components for McpMux",
   "type": "module",

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tests"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 publish = false
 description = "Integration tests for McpMux"


### PR DESCRIPTION
- Reset all Cargo.toml versions to 0.0.1
- Reset all package.json versions to 0.0.1
- Reset tauri.conf.json version to 0.0.1
- Deleted local v0.1.0 tag

This allows release-plz to create a proper v0.1.0 release PR with changelog including all commits since the beginning.