### PR TITLE
chore: reset to v0.0.1 for fresh release-plz start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,3 @@ All notable changes to McpMux will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-## [0.1.0](https://github.com/MCP-Mux/mcp-mux/releases/tag/v0.1.0) - 2026-02-04
-

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -54,7 +54,7 @@ body = """
 trim = true
 protect_breaking_commits = true
 
-# Conventional commit parsing
+# Conventional commit parsing - ORDER MATTERS! Specific patterns must come before generic ones
 commit_parsers = [
     { message = "^feat", group = "Features" },
     { message = "^fix", group = "Bug Fixes" },
@@ -65,9 +65,10 @@ commit_parsers = [
     { message = "^test", group = "Testing" },
     { message = "^chore\\(deps\\)", group = "Dependencies" },
     { message = "^chore\\(release\\)", skip = true },
-    { message = "^chore", skip = true },
-    { message = "^ci", skip = true },
-    { message = "^build", skip = true },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^build", group = "Build" },
+    { message = "^chore", group = "Chores" },
+    { message = "^.*", group = "Other" },
 ]
 
 # Convert issue/PR references to links
@@ -78,8 +79,11 @@ commit_preprocessors = [
 # Only release the main desktop app, not the library crates
 [[package]]
 name = "mcpmux"
+# Path relative to workspace root (not package root)
 changelog_path = "CHANGELOG.md"
 release = true
+# Include commits from internal crates in the main changelog
+changelog_include = ["mcpmux-core", "mcpmux-gateway", "mcpmux-mcp", "mcpmux-storage"]
 
 # Disable release for library crates (they're internal, not published)
 [[package]]


### PR DESCRIPTION
- Reset CHANGELOG.md to header only
- Fix commit_parsers to include ci/build/chore commits instead of skipping
- Add catch-all 'Other' group so no commits are silently dropped
- Add changelog_include to aggregate commits from all internal crates
- This enables proper changelog generation for v0.1.0