### PR TITLE
fix: render server icon URLs as images instead of raw text

### DIFF
--- a/apps/desktop/src/components/ServerIcon.tsx
+++ b/apps/desktop/src/components/ServerIcon.tsx
@@ -1,0 +1,40 @@
+/**
+ * Shared server icon component that handles both URL-based and emoji icons.
+ *
+ * Server definitions may have an `icon` field that is either:
+ * - An HTTP(S) URL to an image (e.g., GitHub avatar)
+ * - An emoji string (e.g., "📦")
+ * - null/undefined
+ */
+
+import { useState } from 'react';
+
+interface ServerIconProps {
+  icon: string | null | undefined;
+  /** CSS classes for the img element when rendering a URL icon */
+  className?: string;
+  /** Fallback emoji when icon is missing or fails to load (default: '📦') */
+  fallback?: string;
+}
+
+export function ServerIcon({ icon, className = 'w-9 h-9 object-contain', fallback = '📦' }: ServerIconProps) {
+  const [failed, setFailed] = useState(false);
+
+  if (!icon || failed) {
+    return <span data-testid="server-icon-fallback">{fallback}</span>;
+  }
+
+  if (icon.startsWith('http')) {
+    return (
+      <img
+        src={icon}
+        alt=""
+        className={className}
+        data-testid="server-icon-img"
+        onError={() => setFailed(true)}
+      />
+    );
+  }
+
+  return <span data-testid="server-icon-emoji">{icon}</span>;
+}

--- a/apps/desktop/src/components/ServerInstallModal.tsx
+++ b/apps/desktop/src/components/ServerInstallModal.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/lib/api/registry';
 import type { ServerDefinition } from '@/types/registry';
 import { useViewSpace } from '@/stores';
+import { ServerIcon } from '@/components/ServerIcon';
 
 /** Deep link payload from backend */
 interface ServerInstallDeepLinkPayload {
@@ -243,9 +244,9 @@ export function ServerInstallModal() {
           {/* Server Info */}
           <div className="p-4 rounded-lg bg-surface-hover border border-[rgb(var(--border))]" data-testid="install-modal-server-info">
             <div className="flex items-center gap-3">
-              {server.icon && (
-                <span className="text-2xl">{server.icon}</span>
-              )}
+              <div className="flex-shrink-0 flex items-center justify-center text-2xl">
+                <ServerIcon icon={server.icon} className="w-8 h-8 object-contain rounded" />
+              </div>
               <div className="flex-1 min-w-0">
                 <div className="font-medium text-lg" data-testid="install-modal-server-name">{server.name}</div>
                 {server.description && (

--- a/apps/desktop/src/features/registry/ServerCard.tsx
+++ b/apps/desktop/src/features/registry/ServerCard.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { ServerViewModel } from '../../types/registry';
+import { ServerIcon } from '../../components/ServerIcon';
 
 interface ServerCardProps {
   server: ServerViewModel;
@@ -103,11 +104,7 @@ export function ServerCard({
       {/* Header */}
       <div className="flex items-start gap-3 mb-3">
         <div className="text-3xl flex-shrink-0 flex items-center justify-center">
-          {server.icon?.startsWith('http') ? (
-            <img src={server.icon} alt="" className="w-9 h-9 object-contain" onError={(e) => { e.currentTarget.style.display = 'none'; e.currentTarget.parentElement!.append(document.createTextNode('📦')); }} />
-          ) : (
-            server.icon || '📦'
-          )}
+          <ServerIcon icon={server.icon} />
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5">

--- a/apps/desktop/src/features/registry/ServerDetailModal.tsx
+++ b/apps/desktop/src/features/registry/ServerDetailModal.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { ServerViewModel } from '../../types/registry';
+import { ServerIcon } from '../../components/ServerIcon';
 
 interface ServerDetailModalProps {
   server: ServerViewModel;
@@ -31,7 +32,9 @@ export function ServerDetailModal({
       <div className="dropdown-menu relative w-full max-w-lg max-h-[90vh] overflow-hidden animate-in fade-in scale-in duration-150">
         {/* Header */}
         <div className="flex items-start gap-4 p-6 border-b border-[rgb(var(--border))]">
-          <div className="text-5xl">{server.icon || '📦'}</div>
+          <div className="flex-shrink-0 flex items-center justify-center">
+            <ServerIcon icon={server.icon} className="w-12 h-12 object-contain rounded-lg" />
+          </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
               <h2 className="text-xl font-bold">

--- a/tests/ts/components/ServerCard.test.tsx
+++ b/tests/ts/components/ServerCard.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ServerCard } from '../../../apps/desktop/src/features/registry/ServerCard';
+import type { ServerViewModel } from '../../../apps/desktop/src/types/registry';
+
+function makeServer(overrides: Partial<ServerViewModel> = {}): ServerViewModel {
+  return {
+    id: 'com.test-server',
+    name: 'Test Server',
+    description: 'A test MCP server',
+    alias: 'test',
+    icon: null,
+    auth: { type: 'none' },
+    transport: {
+      type: 'http',
+      url: 'https://example.com/mcp',
+      headers: {},
+      metadata: { inputs: [] },
+    },
+    categories: ['developer-tools'],
+    publisher: null,
+    source: { type: 'Registry', url: 'https://registry.mcpmux.com', name: 'McpMux Registry' },
+    is_installed: false,
+    enabled: false,
+    oauth_connected: false,
+    input_values: {},
+    connection_status: 'disconnected',
+    missing_required_inputs: false,
+    last_error: null,
+    ...overrides,
+  };
+}
+
+describe('ServerCard', () => {
+  const defaultProps = {
+    onInstall: vi.fn(),
+    onUninstall: vi.fn(),
+    onViewDetails: vi.fn(),
+  };
+
+  describe('icon rendering', () => {
+    it('should render fallback icon when icon is null', () => {
+      const server = makeServer({ icon: null });
+      render(<ServerCard server={server} {...defaultProps} />);
+      expect(screen.getByTestId('server-icon-fallback')).toHaveTextContent('📦');
+    });
+
+    it('should render emoji icon as text', () => {
+      const server = makeServer({ icon: '🔐' });
+      render(<ServerCard server={server} {...defaultProps} />);
+      expect(screen.getByTestId('server-icon-emoji')).toHaveTextContent('🔐');
+    });
+
+    it('should render URL icon as img element', () => {
+      const server = makeServer({
+        icon: 'https://avatars.githubusercontent.com/u/314135?v=4',
+      });
+      render(<ServerCard server={server} {...defaultProps} />);
+      const img = screen.getByTestId('server-icon-img');
+      expect(img.tagName).toBe('IMG');
+      expect(img).toHaveAttribute(
+        'src',
+        'https://avatars.githubusercontent.com/u/314135?v=4'
+      );
+    });
+
+    it('should show fallback when image fails to load', () => {
+      const server = makeServer({
+        icon: 'https://example.com/broken-icon.png',
+      });
+      render(<ServerCard server={server} {...defaultProps} />);
+      const img = screen.getByTestId('server-icon-img');
+      fireEvent.error(img);
+      expect(screen.getByTestId('server-icon-fallback')).toHaveTextContent('📦');
+    });
+  });
+
+  describe('server info', () => {
+    it('should render server name', () => {
+      const server = makeServer({ name: 'GitHub MCP Server' });
+      render(<ServerCard server={server} {...defaultProps} />);
+      expect(screen.getByText('GitHub MCP Server')).toBeInTheDocument();
+    });
+
+    it('should render description', () => {
+      const server = makeServer({ description: 'Manage GitHub repos' });
+      render(<ServerCard server={server} {...defaultProps} />);
+      expect(screen.getByText('Manage GitHub repos')).toBeInTheDocument();
+    });
+
+    it('should render categories', () => {
+      const server = makeServer({
+        categories: ['cloud', 'developer-tools', 'productivity'],
+      });
+      render(<ServerCard server={server} {...defaultProps} />);
+      expect(screen.getByText('cloud')).toBeInTheDocument();
+      expect(screen.getByText('developer-tools')).toBeInTheDocument();
+      expect(screen.getByText('productivity')).toBeInTheDocument();
+    });
+
+    it('should truncate categories beyond 3', () => {
+      const server = makeServer({
+        categories: ['cloud', 'developer-tools', 'productivity', 'extra'],
+      });
+      render(<ServerCard server={server} {...defaultProps} />);
+      expect(screen.getByText('+1')).toBeInTheDocument();
+    });
+  });
+
+  describe('actions', () => {
+    it('should render Install button for non-installed server', () => {
+      const server = makeServer({ is_installed: false });
+      render(<ServerCard server={server} {...defaultProps} />);
+      expect(screen.getByText('Install')).toBeInTheDocument();
+    });
+
+    it('should render Uninstall button for installed server', () => {
+      const server = makeServer({ is_installed: true });
+      render(<ServerCard server={server} {...defaultProps} />);
+      expect(screen.getByText('Uninstall')).toBeInTheDocument();
+    });
+
+    it('should call onViewDetails when card is clicked', () => {
+      const server = makeServer();
+      render(<ServerCard server={server} {...defaultProps} />);
+      fireEvent.click(screen.getByTestId(`server-card-${server.id}`));
+      expect(defaultProps.onViewDetails).toHaveBeenCalledWith(server);
+    });
+  });
+});

--- a/tests/ts/components/ServerDetailModal.test.tsx
+++ b/tests/ts/components/ServerDetailModal.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ServerDetailModal } from '../../../apps/desktop/src/features/registry/ServerDetailModal';
+import type { ServerViewModel } from '../../../apps/desktop/src/types/registry';
+
+function makeServer(overrides: Partial<ServerViewModel> = {}): ServerViewModel {
+  return {
+    id: 'com.test-server',
+    name: 'Test Server',
+    description: 'A test MCP server',
+    alias: 'test',
+    icon: null,
+    auth: { type: 'none' },
+    transport: {
+      type: 'http',
+      url: 'https://example.com/mcp',
+      headers: {},
+      metadata: { inputs: [] },
+    },
+    categories: ['developer-tools'],
+    publisher: null,
+    source: { type: 'Registry', url: 'https://registry.mcpmux.com', name: 'McpMux Registry' },
+    is_installed: false,
+    enabled: false,
+    oauth_connected: false,
+    input_values: {},
+    connection_status: 'disconnected',
+    missing_required_inputs: false,
+    last_error: null,
+    ...overrides,
+  };
+}
+
+describe('ServerDetailModal', () => {
+  const defaultProps = {
+    onClose: vi.fn(),
+    onInstall: vi.fn(),
+    onUninstall: vi.fn(),
+  };
+
+  it('should render server name', () => {
+    const server = makeServer({ name: 'Cloudflare Workers' });
+    render(<ServerDetailModal server={server} {...defaultProps} />);
+    expect(screen.getByText('Cloudflare Workers')).toBeInTheDocument();
+  });
+
+  it('should render fallback icon when icon is null', () => {
+    const server = makeServer({ icon: null });
+    render(<ServerDetailModal server={server} {...defaultProps} />);
+    expect(screen.getByTestId('server-icon-fallback')).toHaveTextContent('📦');
+  });
+
+  it('should render emoji icon as text', () => {
+    const server = makeServer({ icon: '🔐' });
+    render(<ServerDetailModal server={server} {...defaultProps} />);
+    expect(screen.getByTestId('server-icon-emoji')).toHaveTextContent('🔐');
+  });
+
+  it('should render URL icon as img element', () => {
+    const server = makeServer({
+      icon: 'https://avatars.githubusercontent.com/u/314135?v=4',
+    });
+    render(<ServerDetailModal server={server} {...defaultProps} />);
+    const img = screen.getByTestId('server-icon-img');
+    expect(img.tagName).toBe('IMG');
+    expect(img).toHaveAttribute(
+      'src',
+      'https://avatars.githubusercontent.com/u/314135?v=4'
+    );
+  });
+
+  it('should render description', () => {
+    const server = makeServer({ description: 'Manages KV and R2 buckets' });
+    render(<ServerDetailModal server={server} {...defaultProps} />);
+    expect(screen.getByText('Manages KV and R2 buckets')).toBeInTheDocument();
+  });
+
+  it('should render categories', () => {
+    const server = makeServer({ categories: ['cloud', 'developer-tools'] });
+    render(<ServerDetailModal server={server} {...defaultProps} />);
+    expect(screen.getByText('cloud')).toBeInTheDocument();
+    expect(screen.getByText('developer-tools')).toBeInTheDocument();
+  });
+
+  it('should render hosting type for remote server', () => {
+    const server = makeServer({
+      transport: {
+        type: 'http',
+        url: 'https://example.com/mcp',
+        headers: {},
+        metadata: { inputs: [] },
+      },
+    });
+    render(<ServerDetailModal server={server} {...defaultProps} />);
+    expect(screen.getByText(/Remote Server/)).toBeInTheDocument();
+  });
+
+  it('should render Install button for non-installed server', () => {
+    const server = makeServer({ is_installed: false });
+    render(<ServerDetailModal server={server} {...defaultProps} />);
+    expect(screen.getByText('Install')).toBeInTheDocument();
+  });
+
+  it('should render Uninstall button for installed server', () => {
+    const server = makeServer({ is_installed: true });
+    render(<ServerDetailModal server={server} {...defaultProps} />);
+    expect(screen.getByText('Uninstall')).toBeInTheDocument();
+  });
+});

--- a/tests/ts/components/ServerIcon.test.tsx
+++ b/tests/ts/components/ServerIcon.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ServerIcon } from '../../../apps/desktop/src/components/ServerIcon';
+
+describe('ServerIcon', () => {
+  describe('fallback rendering', () => {
+    it('should render default fallback when icon is null', () => {
+      render(<ServerIcon icon={null} />);
+      const fallback = screen.getByTestId('server-icon-fallback');
+      expect(fallback).toBeInTheDocument();
+      expect(fallback).toHaveTextContent('📦');
+    });
+
+    it('should render default fallback when icon is undefined', () => {
+      render(<ServerIcon icon={undefined} />);
+      const fallback = screen.getByTestId('server-icon-fallback');
+      expect(fallback).toBeInTheDocument();
+      expect(fallback).toHaveTextContent('📦');
+    });
+
+    it('should render default fallback when icon is empty string', () => {
+      render(<ServerIcon icon="" />);
+      const fallback = screen.getByTestId('server-icon-fallback');
+      expect(fallback).toBeInTheDocument();
+      expect(fallback).toHaveTextContent('📦');
+    });
+
+    it('should render custom fallback when specified', () => {
+      render(<ServerIcon icon={null} fallback="🔌" />);
+      const fallback = screen.getByTestId('server-icon-fallback');
+      expect(fallback).toHaveTextContent('🔌');
+    });
+  });
+
+  describe('emoji rendering', () => {
+    it('should render emoji icon as text', () => {
+      render(<ServerIcon icon="🔐" />);
+      const emoji = screen.getByTestId('server-icon-emoji');
+      expect(emoji).toBeInTheDocument();
+      expect(emoji).toHaveTextContent('🔐');
+    });
+
+    it('should render non-URL text as emoji', () => {
+      render(<ServerIcon icon="test-icon" />);
+      const emoji = screen.getByTestId('server-icon-emoji');
+      expect(emoji).toBeInTheDocument();
+      expect(emoji).toHaveTextContent('test-icon');
+    });
+  });
+
+  describe('URL icon rendering', () => {
+    it('should render HTTP URL as img element', () => {
+      render(
+        <ServerIcon icon="http://example.com/icon.png" />
+      );
+      const img = screen.getByTestId('server-icon-img');
+      expect(img).toBeInTheDocument();
+      expect(img.tagName).toBe('IMG');
+      expect(img).toHaveAttribute('src', 'http://example.com/icon.png');
+    });
+
+    it('should render HTTPS URL as img element', () => {
+      render(
+        <ServerIcon icon="https://avatars.githubusercontent.com/u/314135?v=4" />
+      );
+      const img = screen.getByTestId('server-icon-img');
+      expect(img).toBeInTheDocument();
+      expect(img.tagName).toBe('IMG');
+      expect(img).toHaveAttribute(
+        'src',
+        'https://avatars.githubusercontent.com/u/314135?v=4'
+      );
+    });
+
+    it('should apply custom className to img element', () => {
+      render(
+        <ServerIcon
+          icon="https://example.com/icon.png"
+          className="w-12 h-12 rounded-lg"
+        />
+      );
+      const img = screen.getByTestId('server-icon-img');
+      expect(img).toHaveClass('w-12', 'h-12', 'rounded-lg');
+    });
+
+    it('should apply default className to img element', () => {
+      render(
+        <ServerIcon icon="https://example.com/icon.png" />
+      );
+      const img = screen.getByTestId('server-icon-img');
+      expect(img).toHaveClass('w-9', 'h-9', 'object-contain');
+    });
+
+    it('should show fallback when image fails to load', () => {
+      render(
+        <ServerIcon icon="https://example.com/broken-icon.png" />
+      );
+      const img = screen.getByTestId('server-icon-img');
+      expect(img).toBeInTheDocument();
+
+      // Simulate image load error
+      fireEvent.error(img);
+
+      // Should now show fallback
+      const fallback = screen.getByTestId('server-icon-fallback');
+      expect(fallback).toBeInTheDocument();
+      expect(fallback).toHaveTextContent('📦');
+    });
+
+    it('should show custom fallback when image fails to load', () => {
+      render(
+        <ServerIcon icon="https://example.com/broken.png" fallback="⚠️" />
+      );
+      const img = screen.getByTestId('server-icon-img');
+      fireEvent.error(img);
+
+      const fallback = screen.getByTestId('server-icon-fallback');
+      expect(fallback).toHaveTextContent('⚠️');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Server definitions use HTTP URLs for the `icon` field (e.g., GitHub avatars), but `ServerDetailModal` and `ServerInstallModal` rendered the URL as raw text instead of an `<img>` element
- Created a shared `ServerIcon` component that detects URL-based icons and renders them as `<img>` elements with graceful error fallback to a 📦 emoji
- Refactored `ServerCard` (which had inline URL detection) to use the shared component for consistency

## Changes
- **New:** `ServerIcon` component (`apps/desktop/src/components/ServerIcon.tsx`) — handles URL icons (`<img>`), emoji icons (`<span>`), and null/error fallback
- **Fixed:** `ServerDetailModal` — was `<div className="text-5xl">{server.icon || '📦'}</div>`, now uses `<ServerIcon>`
- **Fixed:** `ServerInstallModal` — was `<span className="text-2xl">{server.icon}</span>`, now uses `<ServerIcon>`
- **Refactored:** `ServerCard` — replaced inline `startsWith('http')` check + DOM manipulation error handler with `<ServerIcon>`
- **Tests:** 32 new unit tests (ServerIcon: 12, ServerCard: 11, ServerDetailModal: 9)
- **E2E:** 2 new Playwright specs verifying icons render as `<img>` elements in registry cards and detail modal

## Test plan
- [x] Unit tests pass: `pnpm test:ts` (ServerIcon, ServerCard, ServerDetailModal)
- [x] TypeScript type check passes: `pnpm typecheck`
- [x] ESLint passes: `pnpm lint` (0 new errors/warnings)
- [x] Pre-commit hooks pass
- [ ] Manual: Open Discover page → verify server icons show as images, not raw URLs
- [ ] Manual: Click a server card → verify detail modal shows icon image
- [ ] Manual: Trigger deep link install → verify install modal shows icon image
- [ ] E2E: `pnpm test:e2e:web` registry icon rendering tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)