### PR TITLE
Disable macOS builds in CI workflows pending signing key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,60 +189,61 @@ jobs:
 
   # ─────────────────────────────────────────────────────────────
   # Build Verification (macOS only - Linux/Windows covered by e2e-desktop)
+  # Disabled until macOS signing key is available
   # ─────────────────────────────────────────────────────────────
-  build:
-    needs: [rust-check, ts-check]
-    runs-on: macos-latest
-    env:
-      MACOSX_DEPLOYMENT_TARGET: '10.13'
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-apple-darwin
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: aarch64-apple-darwin
-          shared-key: rust-aarch64-apple-darwin
-          cache-on-failure: true
-
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-
-      # Cache pnpm store
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-store-${{ runner.os }}-
-
-      # Cache Tauri CLI binary
-      - name: Cache Tauri CLI
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/cargo-tauri*
-            ~/.cargo/bin/tauri*
-          key: tauri-cli-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            tauri-cli-${{ runner.os }}-
-
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-        env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+  # build:
+  #   needs: [rust-check, ts-check]
+  #   runs-on: macos-latest
+  #   env:
+  #     MACOSX_DEPLOYMENT_TARGET: '10.13'
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #
+  #     - uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         targets: aarch64-apple-darwin
+  #
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         key: aarch64-apple-darwin
+  #         shared-key: rust-aarch64-apple-darwin
+  #         cache-on-failure: true
+  #
+  #     - uses: pnpm/action-setup@v4
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20
+  #         cache: 'pnpm'
+  #
+  #     # Cache pnpm store
+  #     - name: Get pnpm store directory
+  #       shell: bash
+  #       run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+  #
+  #     - name: Cache pnpm store
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: ${{ env.STORE_PATH }}
+  #         key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+  #         restore-keys: |
+  #           pnpm-store-${{ runner.os }}-
+  #
+  #     # Cache Tauri CLI binary
+  #     - name: Cache Tauri CLI
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: |
+  #           ~/.cargo/bin/cargo-tauri*
+  #           ~/.cargo/bin/tauri*
+  #         key: tauri-cli-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+  #         restore-keys: |
+  #           tauri-cli-${{ runner.os }}-
+  #
+  #     - run: pnpm install --frozen-lockfile
+  #     - run: pnpm build
+  #       env:
+  #         TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+  #         TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
   # ─────────────────────────────────────────────────────────────
   # Test Results Report (separate checks per test type and OS)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,8 +23,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: macos-latest
-            target: aarch64-apple-darwin
+          # macOS build disabled until signing key is available
+          # - os: macos-latest
+          #   target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,13 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: windows
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            artifact: macos-arm
-          - os: macos-15
-            target: x86_64-apple-darwin
-            artifact: macos-intel
+          # macOS builds disabled until signing key is available
+          # - os: macos-latest
+          #   target: aarch64-apple-darwin
+          #   artifact: macos-arm
+          # - os: macos-15
+          #   target: x86_64-apple-darwin
+          #   artifact: macos-intel
 
     runs-on: ${{ matrix.os }}
     permissions:


### PR DESCRIPTION
## Summary
Temporarily disable macOS build jobs across all CI workflows (ci.yml, release.yml, and nightly.yml) until the macOS signing key becomes available.

## Changes
- **ci.yml**: Commented out the `build` job that runs on `macos-latest` for build verification
- **release.yml**: Commented out macOS build matrix entries for both ARM64 (`macos-latest`) and Intel (`macos-15`) targets
- **nightly.yml**: Commented out the macOS ARM64 (`macos-latest`) build matrix entry

All changes include explanatory comments indicating the reason for disabling: "macOS builds/signing disabled until signing key is available"

## Details
The macOS builds require code signing credentials (TAURI_SIGNING_PRIVATE_KEY and TAURI_SIGNING_PRIVATE_KEY_PASSWORD) which are currently unavailable. Rather than failing CI runs, these jobs are disabled until the signing infrastructure is properly configured. Linux and Windows builds remain unaffected and continue to run normally.

https://claude.ai/code/session_018FzhWeoXR2NTxZ4LXQ1NJS