### PR TITLE
ci: disable macOS release and nightly builds until signing key is ava…

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,8 +23,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: macos-latest
-            target: aarch64-apple-darwin
+          # macOS build disabled until signing key is available
+          # - os: macos-latest
+          #   target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,13 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: windows
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            artifact: macos-arm
-          - os: macos-15
-            target: x86_64-apple-darwin
-            artifact: macos-intel
+          # macOS builds disabled until signing key is available
+          # - os: macos-latest
+          #   target: aarch64-apple-darwin
+          #   artifact: macos-arm
+          # - os: macos-15
+          #   target: x86_64-apple-darwin
+          #   artifact: macos-intel
 
     runs-on: ${{ matrix.os }}
     permissions:


### PR DESCRIPTION
…ilable

Comment out macOS matrix entries in release and nightly workflows. CI build verification is kept since it doesn't require signing.
