### PR TITLE
Refactor release workflow to use draft releases with explicit publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      release_id: ${{ steps.release.outputs.id }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
     steps:
@@ -141,43 +142,42 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           projectPath: apps/desktop
-          # Use tagName to find and upload to the existing release created by release-please
-          tagName: ${{ needs.release-please.outputs.tag_name }}
-          releaseName: 'McpMux v${{ needs.release-please.outputs.version }}'
-          releaseBody: ''  # Release notes already created by release-please
-          releaseDraft: false
-          prerelease: false
+          # Upload to the existing draft release created by release-please
+          releaseId: ${{ needs.release-please.outputs.release_id }}
           updaterJsonKeepUniversal: true
+
+  # ─────────────────────────────────────────────────────────────
+  # Publish Release: Flip draft → published after all artifacts
+  # are attached, so /releases/latest always has all assets
+  # ─────────────────────────────────────────────────────────────
+  publish-release:
+    needs: [release-please, build-release]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: ${{ needs.release-please.outputs.release_id }},
+              draft: false,
+            });
 
   # ─────────────────────────────────────────────────────────────
   # Update Homebrew Tap: Push new version to homebrew-mcpmux
   # ─────────────────────────────────────────────────────────────
   update-homebrew:
-    needs: [release-please, build-release]
+    needs: [release-please, publish-release]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Wait for release assets
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ needs.release-please.outputs.version }}"
-          TAG="${{ needs.release-please.outputs.tag_name }}"
-          echo "Checking release assets for $TAG..."
-
-          # Wait up to 5 minutes for macOS DMGs to appear
-          for i in $(seq 1 30); do
-            ASSETS=$(gh api repos/${{ github.repository }}/releases/tags/$TAG --jq '.assets[].name' 2>/dev/null || echo "")
-            if echo "$ASSETS" | grep -q "aarch64.dmg" && echo "$ASSETS" | grep -q "x64.dmg"; then
-              echo "Both macOS DMGs found"
-              break
-            fi
-            echo "Waiting for macOS DMGs... (attempt $i/30)"
-            sleep 10
-          done
-
       - name: Compute SHA256 and update cask
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "draft": false,
+      "draft": true,
       "prerelease": false,
       "include-component-in-tag": false,
       "extra-files": [


### PR DESCRIPTION
## Summary
This change refactors the GitHub Actions release workflow to create releases as drafts and explicitly publish them after all build artifacts are attached. This ensures that the `/releases/latest` endpoint always returns a complete release with all assets.

## Key Changes
- **release-please configuration**: Changed `draft` setting from `false` to `true` to create releases in draft state
- **Workflow output**: Added `release_id` output from release-please step to enable direct release manipulation
- **Build step**: Updated to use `releaseId` parameter instead of `tagName` for uploading artifacts to the draft release
- **New publish-release job**: Added dedicated job that converts the draft release to published after all build artifacts are attached
- **Homebrew update**: Updated dependency chain to wait for `publish-release` job instead of `build-release`, and removed the polling logic that waited for assets to appear

## Implementation Details
- The new `publish-release` job uses `actions/github-script` to call the GitHub API and flip the `draft` flag to `false`
- This ensures atomicity: either all assets are present when the release becomes public, or it remains in draft state
- Removed the 5-minute polling loop in the Homebrew update step since the explicit publish step guarantees assets are ready

https://claude.ai/code/session_01JFUTfGHH9TLrwHE1Z6spVJ