### PR TITLE
chore: add --clobber to gh release upload for .sig files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
 
           # Upload all .sig files to the release
           if ls sigs/*.sig &>/dev/null; then
-            gh release upload "$TAG" sigs/*.sig --repo "$REPO"
+            gh release upload "$TAG" sigs/*.sig --repo "$REPO" --clobber
           fi
 
       - name: Publish release


### PR DESCRIPTION
When the release workflow is retried, the .sig files already exist on the
release, causing `gh release upload` to fail. The --clobber flag allows
overwriting existing assets.

Signed-off-by: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01YSiCTG5xhX1fqNV4Vee5PX
Signed-off-by: Claude <noreply@anthropic.com>