### PR TITLE
chore(ci): use correct homebrew-tap repo name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
             --repo "${{ github.repository }}"
 
   # ─────────────────────────────────────────────────────────────
-  # Update Homebrew Tap: Push new version to homebrew-mcpmux
+  # Update Homebrew Tap: Push new version to homebrew-tap
   # ─────────────────────────────────────────────────────────────
   update-homebrew:
     needs: [release-please, publish-release]
@@ -294,7 +294,7 @@ jobs:
           echo "x64   SHA256: $SHA_X64"
 
           # Clone the tap repo and update the cask
-          git clone https://x-access-token:${GH_TOKEN}@github.com/mcpmux/homebrew-mcpmux.git tap
+          git clone https://x-access-token:${GH_TOKEN}@github.com/mcpmux/homebrew-tap.git tap
 
           # Generate cask file (Ruby heredoc content with shell variable expansion)
           CASK_FILE="tap/Casks/mcpmux.rb"


### PR DESCRIPTION
## Summary
- The tap repo was renamed from `homebrew-mcpmux` to `homebrew-tap`, but the `update-homebrew` job in `release.yml` still cloned the old name
- This caused the job to fail, leaving the cask with placeholder SHA256 values and breaking `brew install --cask mcpmux/tap/mcpmux`
- Updated the git clone URL to use the correct `homebrew-tap.git` repo name

## Test plan
- [ ] Trigger a release (or manually run the `update-homebrew` job) and verify it successfully clones `homebrew-tap` and pushes updated SHA256 hashes
- [ ] Run `brew install --cask mcpmux/tap/mcpmux` on a clean machine and confirm it installs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)