### PR TITLE
chore(ci): build Intel macOS DMG and fix deprecated cask directive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: macos-arm
-          - os: macos-latest
+          - os: macos-13
             target: x86_64-apple-darwin
             artifact: macos-intel
 
@@ -129,7 +129,7 @@ jobs:
       # strings as present (Some("")), so we must completely omit the env var.
       # Instead we import the cert here and only pass APPLE_SIGNING_IDENTITY.
       - name: Import Apple certificate
-        if: matrix.os == 'macos-latest' || matrix.os == 'macos-15'
+        if: startsWith(matrix.os, 'macos-')
         id: apple-cert
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
@@ -329,7 +329,6 @@ jobs:
             echo '  desc "Unified MCP gateway and manager for AI clients"'
             echo '  homepage "https://mcpmux.com"'
             echo ''
-            echo '  depends_on macos: ">= :high_sierra"'
             if [ "$HAS_X64" != true ]; then
               echo '  depends_on arch: :arm64'
             fi


### PR DESCRIPTION
## Summary
- Use `macos-13` runner for `x86_64-apple-darwin` target so Tauri natively produces an Intel DMG (`macos-latest` is ARM and can't produce DMGs when cross-compiling)
- Broaden Apple cert import condition to `startsWith(matrix.os, 'macos-')` to cover all macOS runners
- Remove deprecated `depends_on macos: ">= :high_sierra"` from generated cask (causes Homebrew warning)

## Context
`brew install --cask mcpmux/tap/mcpmux` fails on Intel Macs because no x64 DMG exists in any release. The Intel build ran on ARM runners via cross-compilation, which doesn't produce `.dmg` bundles.

## Test plan
- [ ] Trigger a release and verify both `McpMux_*_aarch64.dmg` and `McpMux_*_x64.dmg` appear in assets
- [ ] Verify the generated cask includes dual-arch `sha256` with both arm/intel hashes
- [ ] `brew install --cask mcpmux/tap/mcpmux` works on both ARM and Intel Macs
- [ ] No `depends_on macos: :high_sierra` deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)