### PR TITLE
chore(ci): remove deprecated depends_on macos from cask generator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,7 +330,6 @@ jobs:
             echo '  desc "Unified MCP gateway and manager for AI clients"'
             echo '  homepage "https://mcpmux.com"'
             echo ''
-            echo '  depends_on macos: ">= :high_sierra"'
             if [ "$HAS_X64" != true ]; then
               echo '  depends_on arch: :arm64'
             fi


### PR DESCRIPTION
## Summary
- Removes the deprecated `depends_on macos: ">= :high_sierra"` directive from the generated cask
- This was causing a Homebrew warning during `brew install --cask mcpmux/tap/mcpmux`

🤖 Generated with [Claude Code](https://claude.com/claude-code)