### PR TITLE
fix: allow process restart after update and detect Homebrew version mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,7 +2611,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcpmux"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2635,6 +2635,7 @@ dependencies = [
  "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tokio",
@@ -2649,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-core"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2674,7 +2675,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-gateway"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2714,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-mcp"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2733,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-storage"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5305,6 +5306,16 @@ dependencies = [
  "url",
  "windows 0.61.3",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri-plugin-deep-link = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-process = "2"
 image = { version = "0.25", default-features = false, features = ["png"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "opener:default",
     "deep-link:default",
     "updater:default",
+    "process:allow-restart",
     "dialog:default"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `tauri-plugin-process` dependency and `process:allow-restart` ACL permission so the Tauri updater can relaunch the app after installing an update (fixes "Command plugin:process|restart not allowed by ACL" error on all platforms)
- Adds `get_bundle_version` Rust command that reads `CFBundleShortVersionString` from the on-disk `Info.plist` on macOS to detect when a Homebrew Cask upgrade has replaced the app bundle while still running
- Shows a "Restart Required" banner with a one-click restart button when a version mismatch is detected

## Test plan
- [ ] Verify in-app update flow completes without ACL error (Download and Install → auto-restart)
- [ ] On macOS: simulate Homebrew upgrade by modifying `Info.plist` version, open Settings → confirm "Restart Required" banner appears
- [ ] On Windows/Linux: confirm no bundle version banner appears (command returns null)
- [ ] Confirm "Restart Now" button calls `relaunch()` successfully