### PR TITLE
feat(ui): Contribute / Request affordances wired to registry templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Questions & Help
     url: https://github.com/mcpmux/mcp-mux/discussions/categories/q-a
@@ -6,3 +6,12 @@ contact_links:
   - name: Feature Ideas
     url: https://github.com/mcpmux/mcp-mux/discussions/categories/ideas
     about: Share and discuss feature ideas
+  - name: Contribute a Server Definition (PR)
+    url: https://github.com/mcpmux/mcp-servers/blob/main/CONTRIBUTING.md
+    about: Server definitions live in the mcp-servers repo and land via PR — read the guide
+  - name: Request a Server
+    url: https://github.com/mcpmux/mcp-servers/issues/new?template=request-server.yml
+    about: Ask the community to add an MCP server to the registry
+  - name: Report a Server Definition Bug
+    url: https://github.com/mcpmux/mcp-servers/issues/new?template=bug-report.yml
+    about: Found a broken or incorrect server in the registry? Report it here

--- a/apps/desktop/src/components/ConfigEditorModal.tsx
+++ b/apps/desktop/src/components/ConfigEditorModal.tsx
@@ -6,6 +6,7 @@ import Editor, { type Monaco } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
 import { useToast, ToastContainer } from '@mcpmux/ui';
 import USER_SPACE_CONFIG_SCHEMA from '../../../../schemas/user-space.schema.json';
+import { RequestServerCTA } from './Contribute';
 
 interface ConfigEditorModalProps {
   spaceId: string;
@@ -219,6 +220,12 @@ export function ConfigEditorModal({ spaceId, spaceName, onClose, onSaved }: Conf
           <span className="text-xs text-[rgb(var(--muted))]">
             Ctrl+S save &middot; Ctrl+Shift+F format
           </span>
+        </div>
+
+        {/* Contribute / Request CTA — surfaces the registry templates so users
+            don't have to hand-roll a definition if one already exists upstream. */}
+        <div className="px-4 py-3 border-b border-[rgb(var(--border))] bg-[rgb(var(--surface-dim))]">
+          <RequestServerCTA />
         </div>
 
         {/* Editor Area */}

--- a/apps/desktop/src/components/Contribute.tsx
+++ b/apps/desktop/src/components/Contribute.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from 'react';
+import { Bug, Github, Heart, Lightbulb, Package, SendHorizontal } from 'lucide-react';
+import { Button } from '@mcpmux/ui';
+import { CONTRIBUTE, openExternal } from '@/lib/contribute';
+
+/**
+ * Inline "Didn't find your server?" CTA used on empty search states in the
+ * Registry page and the Add-Custom-Server flow.
+ *
+ * Ships two buttons side-by-side: **Request** (opens a pre-labelled GitHub
+ * issue in mcp-servers with the search term in the title) and
+ * **Contribute** (opens the mcp-servers CONTRIBUTING guide).
+ */
+export function RequestServerCTA({
+  searchTerm,
+  className,
+}: {
+  searchTerm?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`rounded-xl border border-primary-200/60 dark:border-primary-800/40 bg-gradient-to-br from-primary-50/50 to-transparent dark:from-primary-900/10 p-4 flex flex-col sm:flex-row items-start sm:items-center gap-3 ${className ?? ''}`}
+      data-testid="request-server-cta"
+    >
+      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary-500/10 text-primary-600 dark:text-primary-300 flex-shrink-0">
+        <Package className="h-4 w-4" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium">Don&apos;t see what you need?</p>
+        <p className="text-xs text-[rgb(var(--muted))] mt-0.5">
+          {searchTerm
+            ? `We couldn't find "${searchTerm}". Request it from the community registry or open a PR yourself.`
+            : 'Request a new server in the community registry, or add one yourself via a pull request.'}
+        </p>
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => openExternal(CONTRIBUTE.requestServer(searchTerm))}
+          data-testid="request-server-btn"
+        >
+          <SendHorizontal className="h-3 w-3 mr-1.5" />
+          Request
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => openExternal(CONTRIBUTE.contributeServer)}
+          data-testid="contribute-server-btn"
+        >
+          <Github className="h-3 w-3 mr-1.5" />
+          Contribute
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A persistent "Contribute / Report" dropdown menu — the single global
+ * affordance for: open GitHub repo, report a bug, request a feature, open
+ * the server registry. Place wherever you want a friendly "help make mcpmux
+ * better" call-to-action.
+ */
+export function ContributeMenu({
+  variant = 'ghost',
+  size = 'sm',
+}: {
+  variant?: 'primary' | 'secondary' | 'ghost';
+  size?: 'sm' | 'md';
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const items = [
+    {
+      label: 'Request a new server',
+      caption: 'Ask the community to add an MCP server to the registry',
+      icon: Package,
+      href: CONTRIBUTE.requestServer(),
+    },
+    {
+      label: 'Report a bug',
+      caption: 'Something broken in the desktop app or gateway',
+      icon: Bug,
+      href: CONTRIBUTE.bug,
+    },
+    {
+      label: 'Suggest a feature',
+      caption: 'An idea for mcpmux itself',
+      icon: Lightbulb,
+      href: CONTRIBUTE.featureRequest,
+    },
+    {
+      label: 'Open on GitHub',
+      caption: 'Browse source, issues, pull requests',
+      icon: Github,
+      href: CONTRIBUTE.repo,
+    },
+  ];
+
+  return (
+    <div className="relative inline-block" ref={ref}>
+      <Button
+        variant={variant}
+        size={size}
+        onClick={() => setOpen((v) => !v)}
+        data-testid="contribute-menu-trigger"
+      >
+        <Heart className="h-4 w-4 mr-1.5" />
+        Contribute
+      </Button>
+      {open && (
+        <div
+          className="absolute right-0 mt-2 z-20 w-72 rounded-xl border border-[rgb(var(--border))] bg-white dark:bg-zinc-900 shadow-xl p-1"
+          data-testid="contribute-menu"
+        >
+          {items.map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                openExternal(item.href);
+              }}
+              className="w-full text-left flex items-start gap-3 px-3 py-2.5 rounded-lg hover:bg-[rgb(var(--surface))] transition-colors"
+            >
+              <item.icon className="h-4 w-4 mt-0.5 text-[rgb(var(--muted))] flex-shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium">{item.label}</p>
+                <p className="text-[11px] text-[rgb(var(--muted))] leading-snug">
+                  {item.caption}
+                </p>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/registry/RegistryPage.tsx
+++ b/apps/desktop/src/features/registry/RegistryPage.tsx
@@ -12,6 +12,7 @@ import { ServerCard } from './ServerCard';
 import { ServerDetailModal } from './ServerDetailModal';
 import { useViewSpace, useNavigateTo } from '@/stores';
 import { capture } from '@/lib/analytics';
+import { RequestServerCTA, ContributeMenu } from '@/components/Contribute';
 
 export function RegistryPage() {
   const {
@@ -140,13 +141,18 @@ export function RegistryPage() {
       <ToastContainer toasts={toasts} onClose={dismiss} />
       {/* Header */}
       <div className="p-6 border-b border-[rgb(var(--border-subtle))]">
-        <div className="flex items-center gap-3 mb-1">
-          <h1 className="text-2xl font-bold" data-testid="registry-title">Discover Servers</h1>
-          {isOffline && (
-            <span className="px-2 py-0.5 text-xs font-medium bg-amber-500/20 text-amber-600 dark:text-amber-400 rounded-full">
-              Offline
-            </span>
-          )}
+        <div className="flex items-center justify-between gap-3 mb-1">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold" data-testid="registry-title">Discover Servers</h1>
+            {isOffline && (
+              <span className="px-2 py-0.5 text-xs font-medium bg-amber-500/20 text-amber-600 dark:text-amber-400 rounded-full">
+                Offline
+              </span>
+            )}
+          </div>
+          {/* Always-reachable contribute menu — users don't have to trigger
+              an empty search to find the request / bug / feature links. */}
+          <ContributeMenu variant="ghost" size="sm" />
         </div>
         <p className="text-sm text-[rgb(var(--muted))]">
           {isOffline 
@@ -242,7 +248,7 @@ export function RegistryPage() {
             <div className="animate-spin rounded-full h-8 w-8 border-2 border-[rgb(var(--primary))] border-t-transparent" />
           </div>
         ) : displayServers.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full text-[rgb(var(--muted))]">
+          <div className="flex flex-col items-center justify-center h-full text-[rgb(var(--muted))] px-8">
             <svg className="w-16 h-16 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path
                 strokeLinecap="round"
@@ -252,7 +258,12 @@ export function RegistryPage() {
               />
             </svg>
             <p className="text-lg">No servers found</p>
-            <p className="text-sm">Try adjusting your search or filters</p>
+            <p className="text-sm mb-6">Try adjusting your search or filters</p>
+            {/* Empty-search CTA — push the user toward requesting or
+                contributing the missing server rather than just giving up. */}
+            <div className="w-full max-w-xl">
+              <RequestServerCTA searchTerm={searchQuery || undefined} />
+            </div>
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">

--- a/apps/desktop/src/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/features/settings/SettingsPage.tsx
@@ -23,9 +23,15 @@ import {
   XCircle,
   Trash2,
   BarChart3,
+  Github,
+  Bug,
+  Lightbulb,
+  Package,
+  Heart,
 } from 'lucide-react';
 import { useAppStore, useTheme, useAnalyticsEnabled } from '@/stores';
 import { UpdateChecker } from './UpdateChecker';
+import { CONTRIBUTE, openExternal } from '@/lib/contribute';
 
 interface StartupSettings {
   autoLaunch: boolean;
@@ -337,6 +343,54 @@ export function SettingsPage() {
         </CardContent>
       </Card>
 
+      {/* Contribute & feedback — the single global "help make mcpmux
+          better" card. Mirrors the items in <ContributeMenu> so power
+          users have quick access without digging into GitHub. */}
+      <Card data-testid="settings-contribute-section">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Heart className="h-5 w-5" />
+            Contribute &amp; feedback
+          </CardTitle>
+          <CardDescription>
+            mcpmux is open source. Request a server, report a bug, suggest a feature, or jump
+            straight to the source.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <ContributeRow
+              icon={Package}
+              title="Request a new server"
+              subtitle="Ask the community to add an MCP server to the registry"
+              onClick={() => openExternal(CONTRIBUTE.requestServer())}
+              testId="contribute-request-server"
+            />
+            <ContributeRow
+              icon={Bug}
+              title="Report a bug"
+              subtitle="Something broken in the desktop app or gateway"
+              onClick={() => openExternal(CONTRIBUTE.bug)}
+              testId="contribute-report-bug"
+            />
+            <ContributeRow
+              icon={Lightbulb}
+              title="Suggest a feature"
+              subtitle="An idea for mcpmux itself"
+              onClick={() => openExternal(CONTRIBUTE.featureRequest)}
+              testId="contribute-feature-request"
+            />
+            <ContributeRow
+              icon={Github}
+              title="Open on GitHub"
+              subtitle="Browse source, issues, pull requests"
+              onClick={() => openExternal(CONTRIBUTE.repo)}
+              testId="contribute-open-github"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
       {/* Logs Section */}
       <Card>
         <CardHeader>
@@ -405,5 +459,38 @@ export function SettingsPage() {
       </Card>
     </div>
     </>
+  );
+}
+
+/**
+ * Flat row used inside the Contribute card. Local to the Settings page — if
+ * we ever need this elsewhere, promote it into @mcpmux/ui.
+ */
+function ContributeRow({
+  icon: Icon,
+  title,
+  subtitle,
+  onClick,
+  testId,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  subtitle: string;
+  onClick: () => void;
+  testId?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-left flex items-start gap-3 p-3 rounded-lg border border-[rgb(var(--border-subtle))] bg-[rgb(var(--surface))] hover:border-primary-400/60 hover:bg-primary-500/5 transition-colors"
+      data-testid={testId}
+    >
+      <Icon className="h-4 w-4 mt-0.5 text-[rgb(var(--muted))] flex-shrink-0" />
+      <div className="min-w-0">
+        <p className="text-sm font-medium">{title}</p>
+        <p className="text-[11px] text-[rgb(var(--muted))] leading-snug mt-0.5">{subtitle}</p>
+      </div>
+    </button>
   );
 }

--- a/apps/desktop/src/lib/contribute.ts
+++ b/apps/desktop/src/lib/contribute.ts
@@ -19,24 +19,32 @@ export const CONTRIBUTE = {
   serversRepo: 'https://github.com/mcpmux/mcp-servers',
   /** Marketing site. */
   site: 'https://mcpmux.com',
-  /** New bug report, pre-labelled. */
-  bug: 'https://github.com/mcpmux/mcp-mux/issues/new?labels=bug',
-  /** Feature request for the app itself. */
+  /** New bug report, pre-filled with the bug_report template. */
+  bug: 'https://github.com/mcpmux/mcp-mux/issues/new?template=bug_report.yml',
+  /** Feature request for the app itself, pre-filled with the feature_request template. */
   featureRequest:
-    'https://github.com/mcpmux/mcp-mux/issues/new?labels=enhancement',
+    'https://github.com/mcpmux/mcp-mux/issues/new?template=feature_request.yml',
   /**
-   * Request a new server definition in the community registry. Encodes the
-   * user's search term into the issue title when provided.
+   * Request a new server definition in the community registry. Opens the
+   * `request-server.yml` issue template and encodes the user's search term
+   * into the title when provided.
    */
   requestServer(searchTerm?: string): string {
     const base =
-      'https://github.com/mcpmux/mcp-servers/issues/new?labels=server-request';
+      'https://github.com/mcpmux/mcp-servers/issues/new?template=request-server.yml';
     if (!searchTerm) return base;
-    const title = encodeURIComponent(`Request: ${searchTerm.slice(0, 120)}`);
+    const title = encodeURIComponent(`[Request] ${searchTerm.slice(0, 120)}`);
     return `${base}&title=${title}`;
   },
-  /** Root of the server-definitions contributing guide. */
+  /**
+   * Contribute a new server definition — points at the registry's
+   * CONTRIBUTING guide. Server definitions are JSON files landed via PR,
+   * not issues, so we send users straight down the fork → PR path.
+   */
   contributeServer: 'https://github.com/mcpmux/mcp-servers/blob/main/CONTRIBUTING.md',
+  /** Report a bug in an existing server definition. */
+  serverDefinitionBug:
+    'https://github.com/mcpmux/mcp-servers/issues/new?template=bug-report.yml',
 } as const;
 
 /**

--- a/apps/desktop/src/lib/contribute.ts
+++ b/apps/desktop/src/lib/contribute.ts
@@ -1,0 +1,53 @@
+/**
+ * Links + helpers for "Contribute / Request / Report" CTAs scattered across
+ * the app (registry empty-state, settings, etc.).
+ *
+ * All URLs live here so we can update the target org / repo / site from one
+ * place instead of grepping for hardcoded strings.
+ *
+ * Open-in-browser goes through `openUrl` (our Tauri command wrapping
+ * `tauri-plugin-opener`) so the user's default browser handles the URL
+ * rather than loading it inside the webview.
+ */
+
+import { openUrl } from '@/lib/api/gateway';
+
+export const CONTRIBUTE = {
+  /** Main desktop + gateway repo. */
+  repo: 'https://github.com/mcpmux/mcp-mux',
+  /** Community-maintained server-definition registry. */
+  serversRepo: 'https://github.com/mcpmux/mcp-servers',
+  /** Marketing site. */
+  site: 'https://mcpmux.com',
+  /** New bug report, pre-labelled. */
+  bug: 'https://github.com/mcpmux/mcp-mux/issues/new?labels=bug',
+  /** Feature request for the app itself. */
+  featureRequest:
+    'https://github.com/mcpmux/mcp-mux/issues/new?labels=enhancement',
+  /**
+   * Request a new server definition in the community registry. Encodes the
+   * user's search term into the issue title when provided.
+   */
+  requestServer(searchTerm?: string): string {
+    const base =
+      'https://github.com/mcpmux/mcp-servers/issues/new?labels=server-request';
+    if (!searchTerm) return base;
+    const title = encodeURIComponent(`Request: ${searchTerm.slice(0, 120)}`);
+    return `${base}&title=${title}`;
+  },
+  /** Root of the server-definitions contributing guide. */
+  contributeServer: 'https://github.com/mcpmux/mcp-servers/blob/main/CONTRIBUTING.md',
+} as const;
+
+/**
+ * Open an external URL via the Tauri opener plugin. Falls back to the plugin
+ * directly if our gateway wrapper fails (mirrors OAuthConsentModal's pattern).
+ */
+export async function openExternal(url: string): Promise<void> {
+  try {
+    await openUrl(url);
+  } catch {
+    const { openUrl: plugin } = await import('@tauri-apps/plugin-opener');
+    await plugin(url);
+  }
+}


### PR DESCRIPTION
## Summary

Adds end-to-end Contribute / Request affordances across the app and wires them to the issue templates that just landed in [mcpmux/mcp-servers](https://github.com/mcpmux/mcp-servers) (see merged PR #114 there).

Users who hit a dead-end — searched for a server that isn't in the registry, found a bug, wanted to suggest a feature — had no clear in-app path. This PR gives them three coordinated entry points, all opening the user's default browser via the Tauri opener plugin (no in-webview navigation).

## What's new

### New shared module — `lib/contribute.ts`
Centralises every external URL (main repo, servers repo, bug/feature/request-server templates). `CONTRIBUTE.requestServer(searchTerm?)` URL-encodes the search term into the GitHub issue title so a user arriving from the empty-search state lands on a pre-populated form. `openExternal(url)` wraps `openUrl` with the same opener-plugin fallback `OAuthConsentModal` uses.

### New shared components — `components/Contribute.tsx`
- `<RequestServerCTA searchTerm?>` — inline gradient card used on empty-search states. Two-button footer: **Request** (opens the `request-server.yml` template with the search term as the title) + **Contribute** (opens mcp-servers CONTRIBUTING.md).
- `<ContributeMenu>` — dropdown with Request new server / Report bug / Suggest feature / Open on GitHub. Reusable anywhere; lives in the Registry header today.

### Placements
- **Registry page** — `<ContributeMenu>` in the header (always visible). `<RequestServerCTA>` in the empty-results state with the active `searchQuery` threaded into the issue title.
- **Add Custom Server modal** (`ConfigEditorModal`) — `<RequestServerCTA>` above the Monaco editor. Users about to hand-roll a custom server config see a clear nudge to check whether one already exists upstream.
- **Settings** — new "Contribute & feedback" card with a 2-column grid of Request-server / Report-bug / Suggest-feature / Open-on-GitHub tiles (`ContributeRow` helper local to `SettingsPage.tsx`).

### Issue-template wiring
Every link that previously used `?labels=` params now uses `?template=*.yml` so it opens the correct pre-filled GitHub issue form:

| Affordance | Before | After |
|------------|--------|-------|
| Bug report | `?labels=bug` | `?template=bug_report.yml` |
| Feature request | `?labels=enhancement` | `?template=feature_request.yml` |
| Request a server | `?labels=server-request` | `?template=request-server.yml`, title `[Request] …` |
| Contribute a server | *(N/A)* | Direct link to `mcp-servers/CONTRIBUTING.md` — server definitions land via PR, not issues |
| Report broken definition | *(N/A)* | `?template=bug-report.yml` on `mcp-servers` |

### `.github/ISSUE_TEMPLATE/config.yml`
- Enables blank issues.
- Adds three cross-repo contact links surfacing the registry's PR guide, Request-a-Server template, and Report-a-Bug template in the "New issue" chooser. Avoids cross-repo ticket drift — users who accidentally come to `mcp-mux` to report a registry issue see exactly where to go.

## Commit layout

1. `feat(ui): Contribute / Request affordances across the app` — the module + components + Registry/Settings placements (originally a local-only commit on my machine).
2. `feat(ui): wire Contribute/Request affordances to merged registry templates` — template URL switch + `ConfigEditorModal` CTA placement + `config.yml` contact links + blank-issues toggle.

## Test plan

- [ ] `pnpm typecheck` — passes locally
- [ ] `pnpm lint` — no new warnings
- [ ] Launch `pnpm dev`, exercise each affordance:
  - Registry header **Contribute** dropdown → each menu item opens the right GitHub template
  - Empty-search state on Registry → Request/Contribute buttons open the right URLs with search term pre-filled on the title
  - Add Custom Server modal → Request/Contribute CTA renders above the editor
  - Settings → "Contribute & feedback" card renders with 4 tiles, each opens the correct URL
- [ ] Verify on GitHub that the "New issue" chooser for this repo shows the new contact links and the "Open a blank issue" option
- [ ] Check that `request-server.yml` / `bug-report.yml` deep links on mcp-servers resolve (they ship as part of the already-merged mcp-servers PR #114)