### PR TITLE
docs: add Discord community link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ### One app to manage all your MCP servers across every AI client.
 
-**[Website](https://mcpmux.com)** · **[Download](https://mcpmux.com/download)** · **[Discover Servers](https://mcpmux.com)** · **[Features](https://mcpmux.com/features)** · **[Discord](https://discord.gg/8V3Vq2bxU)**
+**[Website](https://mcpmux.com)** · **[Download](https://mcpmux.com/download)** · **[Discover Servers](https://mcpmux.com)** · **[Features](https://mcpmux.com/features)** · **[Discord](https://discord.gg/b4RDmwAHAN)**
 
 ---
 
@@ -228,7 +228,7 @@ mcp-mux/
 - **Download** — [mcpmux.com/download](https://mcpmux.com/download)
 - **Features** — [mcpmux.com/features](https://mcpmux.com/features)
 - **Server Definitions Repo** — [github.com/mcpmux/mcp-servers](https://github.com/mcpmux/mcp-servers)
-- **Community Chat** — [Discord](https://discord.gg/8V3Vq2bxU)
+- **Community Chat** — [Discord](https://discord.gg/b4RDmwAHAN)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ### One app to manage all your MCP servers across every AI client.
 
-**[Website](https://mcpmux.com)** · **[Download](https://mcpmux.com/download)** · **[Discover Servers](https://mcpmux.com)** · **[Features](https://mcpmux.com/features)**
+**[Website](https://mcpmux.com)** · **[Download](https://mcpmux.com/download)** · **[Discover Servers](https://mcpmux.com)** · **[Features](https://mcpmux.com/features)** · **[Discord](https://discord.gg/8V3Vq2bxU)**
 
 ---
 
@@ -228,6 +228,7 @@ mcp-mux/
 - **Download** — [mcpmux.com/download](https://mcpmux.com/download)
 - **Features** — [mcpmux.com/features](https://mcpmux.com/features)
 - **Server Definitions Repo** — [github.com/mcpmux/mcp-servers](https://github.com/mcpmux/mcp-servers)
+- **Community Chat** — [Discord](https://discord.gg/8V3Vq2bxU)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Adds the Discord invite link (`https://discord.gg/8V3Vq2bxU`) to the README's top quick-links row
- Adds a new `Community Chat` item to the `## Links` section near the bottom

## Why
Gives users and contributors a direct entry point to the community server from the main repo landing page.

## Test plan
- [x] Pre-commit hooks pass (format, clippy, eslint, typecheck)
- [ ] README renders cleanly on GitHub (visual check once the PR is open)