### PR TITLE
fix(oauth): skip invalid redirect URIs in DCR instead of failing registration

### DIFF
--- a/crates/mcpmux-gateway/src/oauth/dcr.rs
+++ b/crates/mcpmux-gateway/src/oauth/dcr.rs
@@ -176,15 +176,23 @@ impl DcrError {
 /// 1. Loopback: http://127.0.0.1:PORT/... or http://localhost:PORT/...
 /// 2. Custom URL schemes: cursor://, vscode://, claude://, etc.
 ///
-/// NOT allowed:
+/// NOT allowed (these are filtered from the request, not hard-failed):
 /// - https:// URLs (except for confidential clients with proper secrets)
 /// - http:// URLs to non-loopback addresses
+///
+/// Invalid URIs are silently skipped rather than rejecting the entire registration.
+/// This is necessary because some clients (notably Cursor) send a mix of valid and
+/// invalid redirect URIs in a single DCR request — failing the whole registration
+/// would lock those clients out entirely, even though they only ever use the valid
+/// URIs in practice. An error is only returned if zero valid URIs remain.
 pub fn validate_redirect_uris(uris: &[String]) -> Result<(), DcrError> {
     if uris.is_empty() {
         return Err(DcrError::invalid_redirect_uri(
             "At least one redirect_uri is required",
         ));
     }
+
+    let mut valid_count = 0;
 
     for uri in uris {
         let is_loopback = uri.starts_with("http://127.0.0.1")
@@ -196,20 +204,28 @@ pub fn validate_redirect_uris(uris: &[String]) -> Result<(), DcrError> {
         let is_custom_scheme = !uri.starts_with("http://") && !uri.starts_with("https://");
 
         if !is_loopback && !is_custom_scheme {
+            // Skip invalid URIs (e.g. https://www.cursor.com/agents/mcp/oauth/callback)
+            // rather than rejecting the entire registration — clients like Cursor send a
+            // mix of valid and invalid URIs and only ever use the valid ones in practice.
             warn!(
-                "[DCR] Rejected redirect_uri: {} (must be loopback or custom scheme)",
+                "[DCR] Skipping invalid redirect_uri: {} (must be loopback or custom scheme)",
                 uri
             );
-            return Err(DcrError::invalid_redirect_uri(
-                "Redirect URI must be loopback (http://127.0.0.1 or http://localhost) \
-                 or a custom URL scheme (e.g., cursor://, vscode://)",
-            ));
+            continue;
         }
 
         debug!(
             "[DCR] Validated redirect_uri: {} (loopback={}, custom_scheme={})",
             uri, is_loopback, is_custom_scheme
         );
+        valid_count += 1;
+    }
+
+    if valid_count == 0 {
+        return Err(DcrError::invalid_redirect_uri(
+            "No valid redirect_uris provided — must include at least one loopback \
+             (http://127.0.0.1 or http://localhost) or custom URL scheme (e.g., cursor://, vscode://)",
+        ));
     }
 
     Ok(())
@@ -420,9 +436,32 @@ mod tests {
 
     #[test]
     fn test_reject_invalid_uris() {
-        // Invalid URIs (non-loopback http)
+        // Invalid URIs (non-loopback http) — fail when no valid URIs remain
         assert!(validate_redirect_uris(&["http://example.com/callback".to_string()]).is_err());
         assert!(validate_redirect_uris(&["https://example.com/callback".to_string()]).is_err());
+    }
+
+    #[test]
+    fn test_mixed_valid_and_invalid_uris_pass() {
+        // Real-world case: Cursor sends a mix of valid (custom scheme + loopback) and
+        // invalid (https) URIs. Registration must succeed as long as at least one valid
+        // URI is present — otherwise clients that send any non-loopback HTTPS URI cannot
+        // register at all.
+        let uris = vec![
+            "cursor://anysphere.cursor-mcp/oauth/callback".to_string(),
+            "https://www.cursor.com/agents/mcp/oauth/callback".to_string(),
+            "http://localhost:8787/callback".to_string(),
+        ];
+        assert!(validate_redirect_uris(&uris).is_ok());
+    }
+
+    #[test]
+    fn test_all_invalid_uris_fail() {
+        let uris = vec![
+            "https://www.cursor.com/agents/mcp/oauth/callback".to_string(),
+            "http://example.com/callback".to_string(),
+        ];
+        assert!(validate_redirect_uris(&uris).is_err());
     }
 
     // Note: Integration tests for idempotent registration are better handled

--- a/crates/mcpmux-gateway/src/services/prefix_cache.rs
+++ b/crates/mcpmux-gateway/src/services/prefix_cache.rs
@@ -138,7 +138,7 @@ impl PrefixCacheService {
 
         // Sort by created_at (earliest first)
         // TODO: Add verified status priority when registry supports it
-        servers.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        servers.sort_by_key(|a| a.created_at);
 
         // Clear existing cache for this space
         self.clear_space(space_id).await;


### PR DESCRIPTION
## Problem

`validate_redirect_uris` in `crates/mcpmux-gateway/src/oauth/dcr.rs` hard-fails the entire DCR registration if **any** redirect URI in the request fails validation. This blocks Cursor (and likely other MCP clients) from connecting because Cursor 3.4.20 sends three redirect URIs in a single DCR request — two valid, one invalid:

```
cursor://anysphere.cursor-mcp/oauth/callback   ✓ valid (custom scheme)
https://www.cursor.com/agents/mcp/oauth/callback  ✗ invalid (https non-loopback)
http://localhost:8787/callback                  ✓ valid (loopback)
```

Real-world log output from McpMux v0.3.0:

```
[DCR] Processing registration for: Cursor (redirect_uris: [..3 URIs..])
[DCR] Validated redirect_uri: cursor://anysphere.cursor-mcp/oauth/callback (loopback=false, custom_scheme=true)
[DCR] Rejected redirect_uri: https://www.cursor.com/agents/mcp/oauth/callback (must be loopback or custom scheme)
[DCR] Registration failed: invalid_redirect_uri
← 400
```

Cursor cannot complete OAuth, so it cannot connect to the McpMux gateway at all.

## Fix

Skip invalid URIs with a warn log instead of returning an error. Only fail the registration if **zero** valid URIs remain after filtering.

This is what other MCP-aware OAuth implementations have already converged on:

- [supabase/auth@0fed91a](https://github.com/supabase/auth/commit/0fed91a2725c43c77298a453cedb1eb8a589cd63) — added `cursor://anysphere.cursor-mcp` to allowlist
- TanStack MCP — [relaxed redirect URI validation](https://github.com/TanStack/tanstack.com/issues/667/linked_closing_reference?reference_location=REPO_ISSUES_INDEX)
- Python MCP SDK — same approach
- [MCP Auth docs](https://mcp-auth.cloud/) — explicitly document this requirement

## Behavior change

| Scenario | Before | After |
|---|---|---|
| All valid URIs | ✓ Pass | ✓ Pass |
| Mix of valid + invalid | ✗ Fail (400) | ✓ Pass, invalid skipped with warn log |
| All invalid URIs | ✗ Fail (400) | ✗ Fail (400) — no change |
| Empty list | ✗ Fail | ✗ Fail — no change |

## Tests

Added two new unit tests covering the mixed-validity and all-invalid cases:

- `test_mixed_valid_and_invalid_uris_pass` — reproduces the exact Cursor scenario
- `test_all_invalid_uris_fail` — ensures we don't accidentally accept clients with only invalid URIs

All 5 `oauth::dcr` tests pass locally:

```
test oauth::dcr::tests::test_validate_loopback_uris ... ok
test oauth::dcr::tests::test_mixed_valid_and_invalid_uris_pass ... ok
test oauth::dcr::tests::test_validate_custom_scheme_uris ... ok
test oauth::dcr::tests::test_reject_invalid_uris ... ok
test oauth::dcr::tests::test_all_invalid_uris_fail ... ok

test result: ok. 5 passed; 0 failed
```

## Manual verification

Built locally on macOS arm64, replaced the bundled binary in `/Applications/McpMux.app`, and confirmed:

1. Cursor 3.4.20 successfully registers via DCR (`[DCR] Successfully registered client: Cursor (mcp_36740f70)`)
2. OAuth authorization flow completes, Cursor shows status `needsAuth` → `connected`
3. Notion MCP tools (proxied through the gateway) are visible and callable from Cursor
4. Logs show the invalid URI being skipped, not rejecting the request:
   ```
   [DCR] Skipping invalid redirect_uri: https://www.cursor.com/agents/mcp/oauth/callback
   [DCR] Successfully registered client: Cursor (mcp_36740f70)
   ← 200 (1ms)
   ```

## Notes

- Signed off per DCO (`-s`)
- No changes to public API
- Stricter validation (rejecting all invalid URIs outright) would lock McpMux out of every Cursor user's workflow until Cursor changes how it constructs DCR requests — which is out of scope for this project to wait on