### PR TITLE
Add Emad Mac Mini bot setup MCP server

### DIFF
--- a/crates/mcpmux-core/src/registry/default-registry.json
+++ b/crates/mcpmux-core/src/registry/default-registry.json
@@ -159,6 +159,50 @@
       "auth_type": "none"
     },
 
+    "com.emadibrahim/dedicated-mac-mini-ai-bot-setup": {
+      "id": "com.emadibrahim/dedicated-mac-mini-ai-bot-setup",
+      "name": "Dedicated Mac Mini AI Bot Setup",
+      "description": "Evaluate Emad Ibrahim's read-only MCP endpoint for dedicated Mac Mini AI operator setup, founder-slot availability, pricing, proof, buyer routes, and comparison pages.",
+      "about": "A read-only MCP endpoint for founders comparing a private Mac Mini AI operator against cloud agents, DIY bot setup, or marketplace installers. It exposes offer metadata and live queue details only; it does not create leads, reserve slots, send email, or mutate production data.",
+      "icon": "https://www.emadibrahim.com/favicon.ico",
+      "category": "automation",
+      "categories": ["ai", "developer-tools"],
+      "tags": [
+        "ai-agent",
+        "ai-operator",
+        "automation",
+        "mac-mini",
+        "founder-tools",
+        "telegram-bot",
+        "discord-bot",
+        "openclaw"
+      ],
+      "publisher": {
+        "name": "Emad Ibrahim",
+        "domain": "emadibrahim.com",
+        "url": "https://www.emadibrahim.com",
+        "verified": false
+      },
+      "quality": {
+        "official": true,
+        "verified": false
+      },
+      "links": {
+        "homepage": "https://www.emadibrahim.com/bot-setup/mac-mini-ai-agent-setup?utm_source=mcpmux&utm_medium=directory&utm_campaign=mcp_listing",
+        "documentation": "https://www.emadibrahim.com/mcp",
+        "repository": "https://github.com/eibrahim/dedicated-mac-mini-ai-bot-setup-mcp",
+        "support": "mailto:eibrahim@gmail.com"
+      },
+      "inputs": [],
+      "transport": {
+        "type": "http",
+        "url": "https://www.emadibrahim.com/mcp"
+      },
+      "auth": {
+        "type": "none"
+      }
+    },
+
     "io.modelcontextprotocol/server-filesystem": {
       "id": "io.modelcontextprotocol/server-filesystem",
       "name": "Filesystem",

--- a/crates/mcpmux-core/src/registry/schema.rs
+++ b/crates/mcpmux-core/src/registry/schema.rs
@@ -366,4 +366,27 @@ mod tests {
         assert_eq!(server.required_inputs().len(), 1);
         assert_eq!(server.secret_inputs().len(), 1);
     }
+
+    #[test]
+    fn test_default_registry_includes_emad_mac_mini_bot_setup() {
+        let json = include_str!("default-registry.json");
+        let registry: ServerRegistry = serde_json::from_str(json).unwrap();
+
+        let server = registry
+            .get("com.emadibrahim/dedicated-mac-mini-ai-bot-setup")
+            .expect("Emad's dedicated Mac mini AI bot setup MCP server should be listed");
+
+        assert_eq!(server.name, "Dedicated Mac Mini AI Bot Setup");
+        assert_eq!(
+            server.links.repository.as_deref(),
+            Some("https://github.com/eibrahim/dedicated-mac-mini-ai-bot-setup-mcp")
+        );
+
+        match &server.transport {
+            TransportConfig::Http { url, .. } => {
+                assert_eq!(url, "https://www.emadibrahim.com/mcp");
+            }
+            TransportConfig::Stdio { .. } => panic!("expected HTTP transport"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add Emad Ibrahim's read-only Dedicated Mac Mini AI Bot Setup MCP endpoint to the bundled registry
- include source-tagged homepage, repository, support, and HTTP transport metadata
- add a registry unit test covering the new entry and live endpoint URL

## Verification
- cargo test -p mcpmux-core test_default_registry_includes_emad_mac_mini_bot_setup -- --nocapture
- cargo fmt --all --check
- cargo test -p mcpmux-core --lib
- cargo check -p mcpmux-core
- cargo clippy -p mcpmux-core -- -D warnings
- curl https://www.emadibrahim.com/mcp metadata and JSON-RPC initialize checks