### PR TITLE
ci: fix pre-release gate (release_created is empty, not 'false')

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,9 @@ jobs:
   # ─────────────────────────────────────────────────────────────
   prerelease-version:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'false' && github.event_name == 'push'
+    # release-please-action sets release_created to 'true' or leaves it empty
+    # (never the literal 'false'), so gate on != 'true', not == 'false'.
+    if: needs.release-please.outputs.release_created != 'true' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

On the first merge after #159 ([run 27517243028](https://github.com/mcpmux/mcp-mux/actions/runs/27517243028)) `release-please` succeeded but **no pre-release was built** — `prerelease-version` (and `prerelease-build` / `prerelease-publish`) were skipped.

## Cause

`release-please-action` sets `release_created` to `'true'` when it cuts a release and otherwise leaves it **empty** — it never emits the literal `'false'`. The pre-release gate was:

```yaml
if: needs.release-please.outputs.release_created == 'false' && github.event_name == 'push'
```

`'' == 'false'` is false, so the job never ran on a normal merge. (The same run confirms it: `build-release`, gated on `== 'true'`, was also correctly skipped — only the `== 'false'` branch was wrong.)

## Fix

Gate on `!= 'true'`, which matches both the empty and `'false'` cases:

```yaml
if: needs.release-please.outputs.release_created != 'true' && github.event_name == 'push'
```

Now: normal merge → `release_created` empty → pre-release builds; release-PR merge → `release_created == 'true'` → stable builds and the pre-release jobs skip. One-line change; YAML validated.