### PR TITLE
ci: numeric-only pre-release identifier for Windows MSI

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -40,8 +40,9 @@ jobs:
           set -euo pipefail
           PRE_TAG="${{ inputs.prerelease_tag }}"
           PRE_TAG="v${PRE_TAG#v}"   # normalize leading v
-          # Strip the -pre.N (and any +build) suffix to get the stable version.
-          STABLE_VERSION=$(printf '%s' "${PRE_TAG#v}" | sed -E 's/-pre\..*$//; s/\+.*$//')
+          # Strip the pre-release (-<n>) and any +build suffix to get the
+          # stable version, e.g. 0.4.0-185 -> 0.4.0.
+          STABLE_VERSION=$(printf '%s' "${PRE_TAG#v}" | sed -E 's/-.*$//; s/\+.*$//')
           STABLE_TAG="v${STABLE_VERSION}"
 
           # The commit the pre-release was built from (deref annotated tags).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,12 @@ jobs:
             BASE=$(printf '%s' "$CUR" | awk -F. '{printf "%d.%d.%d", $1, $2, $3 + 1}')
             echo "No open release PR; patch-bumping current ($CUR) -> $BASE"
           fi
-          PRE="${BASE}-pre.${{ github.run_number }}"
+          # The pre-release identifier MUST be numeric-only (a single SemVer
+          # identifier, no "pre." word): the Windows MSI bundler maps it to the
+          # 4th version field and rejects non-numeric / >65535 values. So use
+          # "<base>-<run_number>", e.g. 0.4.0-185. Ordering still holds:
+          # 0.3.0 < 0.4.0-185 < 0.4.0-186 < 0.4.0. (run_number stays < 65535.)
+          PRE="${BASE}-${{ github.run_number }}"
           echo "version=$PRE" >> "$GITHUB_OUTPUT"
           echo "Pre-release version: $PRE"
 


### PR DESCRIPTION
## Problem

First real pre-release run ([27517363876](https://github.com/mcpmux/mcp-mux/actions/runs/27517363876)): Linux + both macOS builds succeeded, but **Windows failed**, so `prerelease-publish` was skipped and `v0.4.0-pre.185` stayed a draft. The MSI bundler errored:

```
failed to bundle project `optional pre-release identifier in app version must be
numeric-only and cannot be greater than 65535 for msi target`
```

MSI maps the SemVer pre-release identifier into the version's 4th field, which must be numeric ≤ 65535 — `pre.185` (the `pre` word) is rejected.

## Fix

Use a **numeric-only** pre-release identifier: `<base>-<run_number>` (e.g. `0.4.0-185`) instead of `<base>-pre.<run_number>`.

- SemVer ordering is unchanged: `0.3.0 < 0.4.0-185 < 0.4.0-186 < 0.4.0`.
- Both channels keep building **MSI** on Windows — important, because stable's updater already targets MSI (`windows-x86_64 → …_x64_en-US.msi`); building NSIS-only for pre-releases would cross installer types when users toggle channels.
- `promote.yml`'s suffix strip generalized from `-pre\.` to `-.*` so it recovers `0.4.0` from `0.4.0-185`.
- GitHub still marks these `prerelease=true`, so channel classification is unaffected.

## Companion

The resolver's version parser needs to accept the new format — **mcpmux.serverhub.api** PR (regex `-(?:pre\.)?(\d+)`). The broken `v0.4.0-pre.185` draft will be deleted; the next merge produces `0.4.0-<run>` cleanly.

`run_number` is 185 today and stays well under the 65535 MSI ceiling.