### PR TITLE
fix(updater): per-user NSIS Windows updates + skip auto-update in dev

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDdCQUZGMEVCMEZBOTk5RTcKUldUbm1ha1A2L0N2ZTlOZjN5T3pGOHBHRUlibytMY2tPeWJkQ01heDJzdTJqK3B3a2lBdDZ1T1oK",
       "windows": {
-        "installMode": "quiet"
+        "installMode": "passive"
       }
     }
   },
@@ -50,7 +50,14 @@
   "bundle": {
     "active": true,
     "createUpdaterArtifacts": true,
-    "targets": "all",
+    "targets": [
+      "app",
+      "dmg",
+      "deb",
+      "rpm",
+      "appimage",
+      "nsis"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -104,6 +104,12 @@ function AppContent() {
   // into the new version — so a restart picks up updates with no clicks.
   // Otherwise just surface the dismissible banner for a manual install.
   useEffect(() => {
+    // Never auto-update under `pnpm dev`. A dev build would otherwise detect a
+    // newer published release, install it over this build, and relaunch — so
+    // your local changes would vanish before you could see them. Production
+    // builds (import.meta.env.DEV === false) are unaffected.
+    if (import.meta.env.DEV) return;
+
     const checkForUpdates = async () => {
       try {
         const { checkForUpdate } = await import('@/lib/updates');

--- a/tests/ts/components/App.test.tsx
+++ b/tests/ts/components/App.test.tsx
@@ -288,6 +288,10 @@ describe('App – dynamic gateway URL display', () => {
 
 describe('App – update banner', () => {
   beforeEach(() => {
+    // The startup auto-update check is gated behind `!import.meta.env.DEV`
+    // (it must never run under `pnpm dev`). Vitest runs in dev mode, so stub
+    // DEV=false here to exercise the production update flow.
+    vi.stubEnv('DEV', false);
     vi.useFakeTimers();
     gatewayEventCallbacks = [];
     setupInvoke({ get_version: '0.1.2' });
@@ -296,6 +300,7 @@ describe('App – update banner', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllEnvs();
   });
 
   it('should show update banner when update is available', async () => {


### PR DESCRIPTION
## What
Fixes the Windows auto-updater so it no longer requires admin and no longer "crashes" (the app exiting to apply an update it can't apply), and stops dev builds from auto-updating over your local changes.

## Root cause
The updater shipped a **per-machine MSI** installed in **`quiet`** mode. Per-machine MSI upgrades need elevation; `quiet` suppresses the UAC prompt; apps run non-elevated by default — so the silent install failed (`1603` / "must be Administrator", `1730`). Because `downloadAndInstall()` quits the app to apply the update, it looked like a crash/loop. This hit **any non-elevated user on auto-update** (auto-install defaults to on), not just `pnpm dev`.

## Changes (`apps/desktop/src-tauri/tauri.conf.json`, `apps/desktop/src/App.tsx`)
- **Drop `msi` from `bundle.targets`** (was `"all"` → explicit list). Windows now ships **NSIS only**, already configured per-user (`nsis.installMode: "currentUser"`), so updates install **without elevation**.
- **`installMode: "quiet"` → `"passive"`** — shows a small progress UI and surfaces a UAC prompt if elevation is ever needed, instead of failing invisibly. With per-user NSIS the normal path still needs no elevation.
- **Skip the startup auto-update under `pnpm dev`** (`if (import.meta.env.DEV) return;`) — a dev build would otherwise detect a newer published release, install it over the dev build, and relaunch, so local changes never appear. Production unaffected.

## No worker change needed
The `api.mcpmux.com` resolver (`pinManifestUrls`) rewrites manifest URLs **filename-agnostically** (path prefix only), so once releases build NSIS-only, `latest.json` will reference the `-setup.exe` and the resolver passes it straight through. Verified the prerelease channel resolves correctly (`0.4.0-191`) — an earlier "wrong version" observation was a bad manual test (header value `pre` instead of `prerelease`), not a resolver bug.

## Tests
`App` update-banner suite stubs `import.meta.env.DEV=false` to keep exercising the production flow — all 12 pass. `tsc --noEmit` clean; ESLint clean (only pre-existing warnings); clippy/fmt clean via pre-commit.

## Takes effect
On the **next release build** (the artifact type is decided at build time). Existing per-machine MSI installs will likely need one manual reinstall via the NSIS `-setup.exe` to fully migrate off the per-machine install.

## Follow-up (not in this PR)
- Verify the discover.ui download page doesn't hardcode a `.msi` asset URL (would 404 once MSI is no longer built).
