### PR TITLE
feat: per-workspace routing via X-Mcpmux-Workspace header + guided folder setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcpmux"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-gateway"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-mcp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-storage"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/desktop/src-tauri/src/commands/gateway.rs
+++ b/apps/desktop/src-tauri/src/commands/gateway.rs
@@ -920,6 +920,23 @@ pub async fn start_gateway(
     let grant_service = server.grant_service();
     let session_roots = server.session_roots();
 
+    // Seed the system-wide inbound-auth toggle into the running gateway from
+    // persisted settings (default: auth required). Live changes go through
+    // `set_gateway_auth_disabled`.
+    {
+        let disabled = app_state
+            .settings_repository
+            .get(GATEWAY_AUTH_DISABLED_KEY)
+            .await
+            .ok()
+            .flatten()
+            .map(|v| v == "true")
+            .unwrap_or(false);
+        if disabled {
+            gw_state.write().await.set_auth_disabled(true);
+        }
+    }
+
     // Subscribe to OAuth completions BEFORE spawn so we don't miss early
     // events emitted during initial auto-connect.
     let oauth_completion_rx = pool_service.oauth_manager().subscribe();
@@ -1103,6 +1120,47 @@ pub async fn reset_gateway_port(app_state: State<'_, AppState>) -> Result<(), St
 
     info!("[Gateway] Cleared persisted gateway port — reverting to default on next start");
     Ok(())
+}
+
+/// App-settings key for the system-wide inbound-auth toggle. Stored as
+/// `"true"`/`"false"`; missing means auth is required (the secure default).
+pub const GATEWAY_AUTH_DISABLED_KEY: &str = "gateway.auth_disabled";
+
+/// Whether inbound MCP authentication is disabled — connections are accepted
+/// without an access key (localhost-only convenience). Default **false** (auth
+/// required).
+#[tauri::command]
+pub async fn get_gateway_auth_disabled(app_state: State<'_, AppState>) -> Result<bool, String> {
+    let stored = app_state
+        .settings_repository
+        .get(GATEWAY_AUTH_DISABLED_KEY)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(stored.map(|v| v == "true").unwrap_or(false))
+}
+
+/// Enable/disable system-wide inbound auth. Persists the setting AND mirrors it
+/// into the running gateway so the change takes effect immediately (no
+/// restart). When the gateway isn't running it's a no-op beyond persistence —
+/// `start_gateway` seeds the value on launch.
+#[tauri::command]
+pub async fn set_gateway_auth_disabled(
+    disabled: bool,
+    app_state: State<'_, AppState>,
+    gateway_state: State<'_, Arc<RwLock<GatewayAppState>>>,
+) -> Result<bool, String> {
+    app_state
+        .settings_repository
+        .set(GATEWAY_AUTH_DISABLED_KEY, &disabled.to_string())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let state = gateway_state.read().await;
+    if let Some(ref gw) = state.gateway_state {
+        gw.write().await.set_auth_disabled(disabled);
+    }
+    info!("[Gateway] Inbound auth disabled set to {}", disabled);
+    Ok(disabled)
 }
 
 /// Which port source a startup attempt would use.

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod server_manager;
 pub mod settings;
 pub mod space;
 pub mod workspace_binding;
+pub mod workspace_install;
 
 // Re-export commands for convenience
 pub use builtin_servers::*;
@@ -40,3 +41,4 @@ pub use server_manager::*;
 pub use settings::*;
 pub use space::*;
 pub use workspace_binding::*;
+pub use workspace_install::*;

--- a/apps/desktop/src-tauri/src/commands/workspace_install.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace_install.rs
@@ -1,0 +1,529 @@
+//! Per-workspace MCP client config installer.
+//!
+//! Registers the McpMux gateway endpoint in a *project-local* MCP client config
+//! (e.g. `.cursor/mcp.json`, `.vscode/mcp.json`) inside a chosen workspace
+//! folder, injecting an `X-Mcpmux-Workspace` header whose value is that folder's
+//! path. The gateway pins that header and routes the connection to the folder's
+//! workspace binding deterministically — even for clients that don't report MCP
+//! `roots` reliably (notably Cursor). This is the "less manual work" path: pick
+//! a folder, pick clients, and McpMux writes (or extends) each client's config.
+//!
+//! Distinct from `config_export` (which exports the *upstream server list* to a
+//! client): here we register the single gateway entry with a per-workspace
+//! header.
+//!
+//! Only clients with a true **project-local** config scope are supported — a
+//! global config can hold only one header value and so can't be per-workspace.
+//! Windsurf/Cline (global-only) and Claude Desktop (stdio, no static headers)
+//! are intentionally excluded.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde_json::json;
+use tracing::info;
+
+/// The server name McpMux registers itself under in every client config.
+const SERVER_NAME: &str = "mcpmux";
+
+/// The per-workspace routing header. Its value is the workspace folder path.
+const WORKSPACE_HEADER: &str = "X-Mcpmux-Workspace";
+
+/// Static description of one client's project-local MCP config shape. The
+/// research-backed differences between clients live here and nowhere else, so
+/// the writer and the UI share a single source of truth.
+#[derive(Debug, Clone, Copy)]
+struct ClientSpec {
+    /// Stable id used by the API and UI (e.g. "cursor").
+    id: &'static str,
+    /// Human label for the UI.
+    label: &'static str,
+    /// Path of the config file relative to the workspace folder, as segments
+    /// (e.g. `[".cursor", "mcp.json"]`).
+    rel_path: &'static [&'static str],
+    /// Top-level object the server entry nests under. Differs across clients:
+    /// `mcpServers` (Cursor/Claude Code), `servers` (VS Code), `mcp`
+    /// (opencode), `context_servers` (Zed).
+    servers_key: &'static str,
+    /// The key the endpoint URL goes under (always `url` for the project-local
+    /// clients we support; Windsurf's `serverUrl` is global-only and excluded).
+    url_key: &'static str,
+    /// The transport `type` value, when the client requires one. `http` for
+    /// Claude Code / VS Code, `remote` for opencode; Cursor and Zed infer it
+    /// from the presence of `url`, so they get `None`.
+    type_value: Option<&'static str>,
+}
+
+/// The supported project-local clients. Adding a client is a one-line table
+/// entry plus a test.
+const CLIENTS: &[ClientSpec] = &[
+    ClientSpec {
+        id: "cursor",
+        label: "Cursor",
+        rel_path: &[".cursor", "mcp.json"],
+        servers_key: "mcpServers",
+        url_key: "url",
+        type_value: None,
+    },
+    ClientSpec {
+        id: "claude-code",
+        label: "Claude Code",
+        rel_path: &[".mcp.json"],
+        servers_key: "mcpServers",
+        url_key: "url",
+        type_value: Some("http"),
+    },
+    ClientSpec {
+        id: "vscode",
+        label: "VS Code / Copilot",
+        rel_path: &[".vscode", "mcp.json"],
+        servers_key: "servers",
+        url_key: "url",
+        type_value: Some("http"),
+    },
+    ClientSpec {
+        id: "opencode",
+        label: "opencode",
+        rel_path: &["opencode.json"],
+        servers_key: "mcp",
+        url_key: "url",
+        type_value: Some("remote"),
+    },
+    ClientSpec {
+        id: "zed",
+        label: "Zed",
+        rel_path: &[".zed", "settings.json"],
+        servers_key: "context_servers",
+        url_key: "url",
+        type_value: None,
+    },
+];
+
+fn find_client(id: &str) -> Option<&'static ClientSpec> {
+    CLIENTS.iter().find(|c| c.id == id)
+}
+
+/// The config file path for a client inside a workspace folder.
+fn config_path(spec: &ClientSpec, workspace_dir: &Path) -> PathBuf {
+    let mut p = workspace_dir.to_path_buf();
+    for seg in spec.rel_path {
+        p.push(seg);
+    }
+    p
+}
+
+/// Build the McpMux server entry for a client. The header value is the
+/// workspace folder path; an optional bearer token is added as `Authorization`
+/// when inbound auth is enabled.
+fn build_entry(
+    spec: &ClientSpec,
+    mcp_url: &str,
+    header_value: &str,
+    bearer: Option<&str>,
+) -> serde_json::Value {
+    let mut headers = serde_json::Map::new();
+    headers.insert(WORKSPACE_HEADER.to_string(), json!(header_value));
+    if let Some(token) = bearer {
+        headers.insert(
+            "Authorization".to_string(),
+            json!(format!("Bearer {token}")),
+        );
+    }
+
+    let mut entry = serde_json::Map::new();
+    // `type` first when present, then url, then headers — cosmetic but stable.
+    if let Some(t) = spec.type_value {
+        entry.insert("type".to_string(), json!(t));
+    }
+    entry.insert(spec.url_key.to_string(), json!(mcp_url));
+    entry.insert("headers".to_string(), serde_json::Value::Object(headers));
+    serde_json::Value::Object(entry)
+}
+
+/// Merge the McpMux entry into an existing config (or a fresh `{}` when there's
+/// none), preserving every other server already configured. Returns the
+/// pretty-printed file content.
+///
+/// Refuses to touch a file that isn't plain JSON (e.g. JSONC with comments) or
+/// whose root / servers key isn't an object — the caller surfaces that as an
+/// error rather than clobbering the user's file.
+fn merge_entry(
+    existing: Option<&str>,
+    spec: &ClientSpec,
+    entry: serde_json::Value,
+) -> Result<String, String> {
+    let mut root: serde_json::Value = match existing {
+        Some(s) if !s.trim().is_empty() => serde_json::from_str(s).map_err(|e| {
+            format!("existing config is not plain JSON ({e}); edit it by hand to add McpMux")
+        })?,
+        _ => json!({}),
+    };
+
+    let obj = root
+        .as_object_mut()
+        .ok_or_else(|| "existing config root is not a JSON object".to_string())?;
+
+    let servers = obj.entry(spec.servers_key).or_insert_with(|| json!({}));
+    let servers = servers.as_object_mut().ok_or_else(|| {
+        format!(
+            "'{}' in the existing config is not an object",
+            spec.servers_key
+        )
+    })?;
+
+    servers.insert(SERVER_NAME.to_string(), entry);
+
+    let mut out = serde_json::to_string_pretty(&root).map_err(|e| e.to_string())?;
+    out.push('\n');
+    Ok(out)
+}
+
+/// Result of installing into one client's config.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkspaceInstallResult {
+    pub client: String,
+    pub label: String,
+    /// Absolute path of the config file written (or that failed).
+    pub path: String,
+    /// "created" | "updated" | "error".
+    pub action: String,
+    /// Path of the backup written when an existing file was modified.
+    pub backed_up: Option<String>,
+    /// Error message when `action == "error"`.
+    pub error: Option<String>,
+}
+
+fn error_result(spec: &ClientSpec, path: &Path, msg: String) -> WorkspaceInstallResult {
+    WorkspaceInstallResult {
+        client: spec.id.to_string(),
+        label: spec.label.to_string(),
+        path: path.to_string_lossy().to_string(),
+        action: "error".to_string(),
+        backed_up: None,
+        error: Some(msg),
+    }
+}
+
+/// Write (or extend) one client's config. Backs up an existing file before
+/// modifying it, and creates parent directories as needed.
+fn install_one(
+    spec: &ClientSpec,
+    workspace_dir: &Path,
+    mcp_url: &str,
+    header_value: &str,
+    bearer: Option<&str>,
+) -> WorkspaceInstallResult {
+    let path = config_path(spec, workspace_dir);
+    let existed = path.exists();
+
+    let existing = if existed {
+        match std::fs::read_to_string(&path) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                return error_result(spec, &path, format!("failed to read existing config: {e}"))
+            }
+        }
+    } else {
+        None
+    };
+
+    let entry = build_entry(spec, mcp_url, header_value, bearer);
+    let merged = match merge_entry(existing.as_deref(), spec, entry) {
+        Ok(m) => m,
+        Err(e) => return error_result(spec, &path, e),
+    };
+
+    // Back up an existing file before overwriting.
+    let mut backed_up = None;
+    if existed {
+        let bak = PathBuf::from(format!("{}.mcpmux-bak", path.display()));
+        if let Err(e) = std::fs::copy(&path, &bak) {
+            return error_result(
+                spec,
+                &path,
+                format!("failed to back up existing config: {e}"),
+            );
+        }
+        backed_up = Some(bak.to_string_lossy().to_string());
+    }
+
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            return error_result(
+                spec,
+                &path,
+                format!("failed to create config directory: {e}"),
+            );
+        }
+    }
+    if let Err(e) = std::fs::write(&path, merged) {
+        return error_result(spec, &path, format!("failed to write config: {e}"));
+    }
+
+    WorkspaceInstallResult {
+        client: spec.id.to_string(),
+        label: spec.label.to_string(),
+        path: path.to_string_lossy().to_string(),
+        action: if existed { "updated" } else { "created" }.to_string(),
+        backed_up,
+        error: None,
+    }
+}
+
+/// One supported client, for the UI checklist.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkspaceInstallClient {
+    pub id: String,
+    pub label: String,
+    /// The project-local config path, shown to the user (e.g. ".cursor/mcp.json").
+    pub config_path: String,
+}
+
+/// List the clients the per-workspace installer supports.
+#[tauri::command]
+pub fn list_workspace_install_clients() -> Vec<WorkspaceInstallClient> {
+    CLIENTS
+        .iter()
+        .map(|c| WorkspaceInstallClient {
+            id: c.id.to_string(),
+            label: c.label.to_string(),
+            config_path: c.rel_path.join("/"),
+        })
+        .collect()
+}
+
+/// A copy-paste config snippet for one client.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkspaceConfigSnippet {
+    pub client: String,
+    pub label: String,
+    /// Where this would be written, relative to the workspace folder.
+    pub config_path: String,
+    /// Full file content (top-level key + the McpMux entry), ready to paste
+    /// into a fresh file.
+    pub content: String,
+}
+
+/// Generate a copy-paste config snippet for one client without writing anything.
+#[tauri::command]
+pub fn generate_workspace_config_snippet(
+    client: String,
+    server_url: String,
+    workspace_root: String,
+    bearer: Option<String>,
+) -> Result<WorkspaceConfigSnippet, String> {
+    let spec = find_client(&client).ok_or_else(|| format!("unknown client '{client}'"))?;
+    let entry = build_entry(spec, &server_url, &workspace_root, bearer.as_deref());
+    // A full-file snippet (top-level key included) so it pastes cleanly into an
+    // empty project config; merging into an existing file is what the install
+    // command is for.
+    let content = merge_entry(None, spec, entry)?;
+    Ok(WorkspaceConfigSnippet {
+        client: spec.id.to_string(),
+        label: spec.label.to_string(),
+        config_path: spec.rel_path.join("/"),
+        content,
+    })
+}
+
+/// Install (create or extend) the McpMux gateway entry into the chosen clients'
+/// project-local configs inside `workspace_root`, injecting the
+/// `X-Mcpmux-Workspace` header set to `workspace_root`.
+///
+/// `server_url` is the gateway MCP endpoint (e.g.
+/// `http://localhost:45818/mcp`). `bearer` is an optional access token to embed
+/// as `Authorization` when inbound auth is enabled; omit it when auth is
+/// disabled.
+#[tauri::command]
+pub fn install_workspace_mcp_config(
+    workspace_root: String,
+    server_url: String,
+    clients: Vec<String>,
+    bearer: Option<String>,
+) -> Result<Vec<WorkspaceInstallResult>, String> {
+    let dir = PathBuf::from(&workspace_root);
+    if !dir.is_dir() {
+        return Err(format!("workspace folder does not exist: {workspace_root}"));
+    }
+    if server_url.trim().is_empty() {
+        return Err("server URL is empty".to_string());
+    }
+    if clients.is_empty() {
+        return Err("no clients selected".to_string());
+    }
+
+    let mut results = Vec::with_capacity(clients.len());
+    for id in &clients {
+        match find_client(id) {
+            Some(spec) => {
+                results.push(install_one(
+                    spec,
+                    &dir,
+                    &server_url,
+                    &workspace_root,
+                    bearer.as_deref(),
+                ));
+            }
+            None => {
+                results.push(WorkspaceInstallResult {
+                    client: id.clone(),
+                    label: id.clone(),
+                    path: String::new(),
+                    action: "error".to_string(),
+                    backed_up: None,
+                    error: Some(format!("unknown client '{id}'")),
+                });
+            }
+        }
+    }
+
+    let ok = results.iter().filter(|r| r.action != "error").count();
+    info!(
+        "[WorkspaceInstall] {} of {} client config(s) written for {}",
+        ok,
+        results.len(),
+        workspace_root
+    );
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn spec(id: &str) -> &'static ClientSpec {
+        find_client(id).unwrap()
+    }
+
+    #[test]
+    fn builds_entry_with_header_and_optional_type() {
+        // Cursor: no type, url + headers.
+        let cursor = build_entry(
+            spec("cursor"),
+            "http://localhost:45818/mcp",
+            "d:\\proj",
+            None,
+        );
+        assert_eq!(cursor["url"], "http://localhost:45818/mcp");
+        assert_eq!(cursor["headers"][WORKSPACE_HEADER], "d:\\proj");
+        assert!(cursor.get("type").is_none());
+
+        // VS Code: type=http.
+        let vscode = build_entry(spec("vscode"), "http://x/mcp", "/p", None);
+        assert_eq!(vscode["type"], "http");
+
+        // opencode: type=remote.
+        let oc = build_entry(spec("opencode"), "http://x/mcp", "/p", None);
+        assert_eq!(oc["type"], "remote");
+    }
+
+    #[test]
+    fn bearer_token_becomes_authorization_header() {
+        let e = build_entry(spec("cursor"), "http://x/mcp", "/p", Some("abc123"));
+        assert_eq!(e["headers"]["Authorization"], "Bearer abc123");
+    }
+
+    #[test]
+    fn merge_into_empty_creates_top_level_key() {
+        let entry = build_entry(spec("cursor"), "http://x/mcp", "/p", None);
+        let out = merge_entry(None, spec("cursor"), entry).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["mcpServers"]["mcpmux"]["url"], "http://x/mcp");
+    }
+
+    #[test]
+    fn vscode_uses_servers_key() {
+        let entry = build_entry(spec("vscode"), "http://x/mcp", "/p", None);
+        let out = merge_entry(None, spec("vscode"), entry).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["servers"]["mcpmux"]["type"], "http");
+        assert!(v.get("mcpServers").is_none());
+    }
+
+    #[test]
+    fn merge_preserves_other_servers() {
+        let existing = r#"{
+            "mcpServers": {
+                "other": { "url": "http://other/mcp" }
+            },
+            "someOtherTopLevel": 42
+        }"#;
+        let entry = build_entry(spec("cursor"), "http://x/mcp", "/p", None);
+        let out = merge_entry(Some(existing), spec("cursor"), entry).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        // Our entry is added...
+        assert_eq!(v["mcpServers"]["mcpmux"]["url"], "http://x/mcp");
+        // ...the sibling server is preserved...
+        assert_eq!(v["mcpServers"]["other"]["url"], "http://other/mcp");
+        // ...and unrelated top-level keys are untouched.
+        assert_eq!(v["someOtherTopLevel"], 42);
+    }
+
+    #[test]
+    fn merge_replaces_an_existing_mcpmux_entry() {
+        let existing = r#"{ "mcpServers": { "mcpmux": { "url": "http://old/mcp" } } }"#;
+        let entry = build_entry(spec("cursor"), "http://new/mcp", "/p", None);
+        let out = merge_entry(Some(existing), spec("cursor"), entry).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["mcpServers"]["mcpmux"]["url"], "http://new/mcp");
+    }
+
+    #[test]
+    fn merge_rejects_non_json_existing() {
+        // JSONC with a comment is not plain JSON — refuse rather than clobber.
+        let existing = "{ // a comment\n  \"servers\": {} }";
+        let entry = build_entry(spec("vscode"), "http://x/mcp", "/p", None);
+        assert!(merge_entry(Some(existing), spec("vscode"), entry).is_err());
+    }
+
+    #[test]
+    fn merge_rejects_non_object_servers_key() {
+        let existing = r#"{ "mcpServers": "oops" }"#;
+        let entry = build_entry(spec("cursor"), "http://x/mcp", "/p", None);
+        assert!(merge_entry(Some(existing), spec("cursor"), entry).is_err());
+    }
+
+    #[test]
+    fn install_creates_then_updates_with_backup() {
+        let tmp = std::env::temp_dir().join(format!("mcpmux-wsinstall-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        // First install → created, no backup.
+        let r1 = install_one(
+            spec("cursor"),
+            &tmp,
+            "http://x/mcp",
+            &tmp.to_string_lossy(),
+            None,
+        );
+        assert_eq!(r1.action, "created", "{:?}", r1.error);
+        assert!(r1.backed_up.is_none());
+        let written = std::fs::read_to_string(config_path(spec("cursor"), &tmp)).unwrap();
+        assert!(written.contains("mcpmux"));
+        assert!(written.contains(WORKSPACE_HEADER));
+
+        // Second install → updated, with backup.
+        let r2 = install_one(
+            spec("cursor"),
+            &tmp,
+            "http://y/mcp",
+            &tmp.to_string_lossy(),
+            None,
+        );
+        assert_eq!(r2.action, "updated");
+        assert!(r2.backed_up.is_some());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn snippet_lists_all_clients() {
+        let clients = list_workspace_install_clients();
+        let ids: Vec<&str> = clients.iter().map(|c| c.id.as_str()).collect();
+        for expected in ["cursor", "claude-code", "vscode", "opencode", "zed"] {
+            assert!(ids.contains(&expected), "missing {expected}");
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -945,6 +945,8 @@ pub fn run() {
             commands::get_gateway_port_settings,
             commands::set_gateway_port,
             commands::reset_gateway_port,
+            commands::get_gateway_auth_disabled,
+            commands::set_gateway_auth_disabled,
             commands::probe_gateway_start,
             commands::take_pending_port_conflict,
             commands::start_gateway,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -921,6 +921,10 @@ pub fn run() {
             commands::delete_workspace_binding,
             commands::validate_workspace_root,
             commands::get_workspace_effective_features,
+            // Per-workspace MCP client config install (X-Mcpmux-Workspace header)
+            commands::list_workspace_install_clients,
+            commands::generate_workspace_config_snippet,
+            commands::install_workspace_mcp_config,
             // Meta-tool approval (self-management mcpmux_* tools)
             commands::respond_to_meta_tool_approval,
             commands::list_meta_tool_grants,

--- a/apps/desktop/src/features/clients/ClientsPage.tsx
+++ b/apps/desktop/src/features/clients/ClientsPage.tsx
@@ -565,7 +565,10 @@ function SidePanel({
               <p className="text-sm font-semibold">Routing is workspace-driven</p>
               <p className="mt-1 text-xs text-[rgb(var(--muted))]">
                 When this client reports a folder as an MCP root, mcpmux uses the matching Workspace
-                binding to pick the Space and FeatureSet.
+                binding to pick the Space and FeatureSet. If it doesn&apos;t report the folder
+                reliably (e.g. Cursor), open the folder in Workspaces and{' '}
+                <span className="font-medium text-[rgb(var(--foreground))]">Connect apps to this folder</span>{' '}
+                to auto-write its config with a workspace header.
               </p>
               <button
                 onClick={onOpenWorkspaces}

--- a/apps/desktop/src/features/home/HomePage.tsx
+++ b/apps/desktop/src/features/home/HomePage.tsx
@@ -10,12 +10,21 @@
  * the page that manages what it counts.
  */
 import { useEffect, useState, useCallback } from 'react';
-import { Server, Wrench, Monitor, Globe, ArrowUpRight, Compass, ArrowRight } from 'lucide-react';
+import {
+  Server,
+  Wrench,
+  Monitor,
+  Globe,
+  ArrowUpRight,
+  Compass,
+  ArrowRight,
+  FolderPlus,
+} from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { PageHeader } from '@mcpmux/ui';
 import { ConnectionCard } from '@/components/ConnectionCard';
 import { useGatewayEvents, useServerStatusEvents, useDomainEvents } from '@/hooks/useDomainEvents';
-import { useViewSpace, useNavigateTo } from '@/stores';
+import { useViewSpace, useNavigateTo, useSetPendingWorkspaceNew } from '@/stores';
 import type { NavItem } from '@/stores/types';
 import { spaceAccentColor } from '@/lib/spaceAccent';
 
@@ -152,6 +161,39 @@ function GetStartedStrip() {
   );
 }
 
+/**
+ * Per-folder setup entry point. The ConnectionCard above connects an app to
+ * the gateway globally; this routes into the Workspaces walkthrough to map a
+ * specific project and write its per-folder config.
+ */
+function SetUpFolderCard() {
+  const navigateTo = useNavigateTo();
+  const openWizard = useSetPendingWorkspaceNew();
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        openWizard(true);
+        navigateTo('workspaces');
+      }}
+      data-testid="home-setup-folder"
+      className="group flex w-full items-center gap-3 rounded-xl border border-[rgb(var(--border-subtle))] bg-[rgb(var(--card))] p-4 text-left shadow transition-all duration-200 hover:-translate-y-0.5 hover:border-[rgb(var(--border))] hover:shadow-md"
+    >
+      <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-[rgb(var(--primary))]/12 text-[rgb(var(--primary))]">
+        <FolderPlus className="h-5 w-5" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-semibold">Set up a folder</span>
+        <span className="block text-xs text-[rgb(var(--muted))]">
+          Map a project to its tools and connect your apps to it — even ones that don&apos;t report
+          the folder.
+        </span>
+      </span>
+      <ArrowRight className="h-4 w-4 flex-shrink-0 text-[rgb(var(--muted))] transition-transform group-hover:translate-x-0.5" />
+    </button>
+  );
+}
+
 export function HomePage() {
   const [stats, setStats] = useState({
     installedServers: 0,
@@ -232,6 +274,9 @@ export function HomePage() {
       {/* Canonical connection surface — owns URL, Start/Stop, IDE grid,
           pending-approval nudge. */}
       <ConnectionCard />
+
+      {/* Per-folder setup — opens the Workspaces walkthrough. */}
+      <SetUpFolderCard />
 
       {/* Stat tiles — each is a shortcut into the page that manages it. */}
       <div

--- a/apps/desktop/src/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/features/settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import {
   Card,
@@ -33,7 +33,13 @@ import {
   AlertCircle,
   ShieldOff,
 } from 'lucide-react';
-import { useAppStore, useTheme, useAnalyticsEnabled } from '@/stores';
+import {
+  useAppStore,
+  useTheme,
+  useAnalyticsEnabled,
+  usePendingSettingsSection,
+  useSetPendingSettingsSection,
+} from '@/stores';
 import { UpdateChecker } from './UpdateChecker';
 import { useGatewayControl } from '@/features/gateway/useGatewayControl';
 import { CONTRIBUTE, openExternal } from '@/lib/contribute';
@@ -59,6 +65,22 @@ export function SettingsPage() {
   const [openingLogs, setOpeningLogs] = useState(false);
   const { toasts, success, error } = useToast();
   const gatewayControl = useGatewayControl();
+
+  // Deep-link: when another surface routes here for a specific section, scroll
+  // it into view and briefly flash it so the user lands on the right control.
+  const pendingSection = usePendingSettingsSection();
+  const clearPendingSection = useSetPendingSettingsSection();
+  const securityRef = useRef<HTMLDivElement>(null);
+  const [flashSecurity, setFlashSecurity] = useState(false);
+
+  useEffect(() => {
+    if (pendingSection !== 'security' || !securityRef.current) return;
+    securityRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    setFlashSecurity(true);
+    clearPendingSection(null);
+    const t = setTimeout(() => setFlashSecurity(false), 2200);
+    return () => clearTimeout(t);
+  }, [pendingSection, clearPendingSection]);
 
   // Startup settings state
   const [startupSettings, setStartupSettings] = useState<StartupSettings>({
@@ -626,6 +648,15 @@ export function SettingsPage() {
         </Card>
 
         {/* Security Section */}
+        <div
+          ref={securityRef}
+          id="settings-security"
+          className={
+            flashSecurity
+              ? 'rounded-xl ring-2 ring-primary-500 ring-offset-2 ring-offset-[rgb(var(--background))] transition-shadow duration-500'
+              : 'rounded-xl ring-0 transition-shadow duration-500'
+          }
+        >
         <Card data-testid="settings-security-section">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
@@ -643,10 +674,8 @@ export function SettingsPage() {
                 <div>
                   <label className="text-sm font-medium">Disable authentication</label>
                   <p className="mt-1 text-xs text-[rgb(var(--muted))]">
-                    Let local apps connect to the gateway with no access key — just the URL and a
-                    workspace header. Makes one-click per-workspace setup trivial. The gateway only
-                    listens on localhost, but any app on this machine can then reach it. Leave on
-                    unless you want the simplest setup.
+                    Let local apps connect with no access key — just the URL and a workspace header.
+                    Quickest setup, but any app on this machine can then reach the gateway.
                   </p>
                 </div>
               </div>
@@ -659,6 +688,7 @@ export function SettingsPage() {
             </div>
           </CardContent>
         </Card>
+        </div>
 
         {/* Appearance Section */}
         <Card>

--- a/apps/desktop/src/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/features/settings/SettingsPage.tsx
@@ -31,6 +31,7 @@ import {
   Network,
   RotateCcw,
   AlertCircle,
+  ShieldOff,
 } from 'lucide-react';
 import { useAppStore, useTheme, useAnalyticsEnabled } from '@/stores';
 import { UpdateChecker } from './UpdateChecker';
@@ -76,6 +77,11 @@ export function SettingsPage() {
   // opens an unmapped folder. On by default.
   const [mappingPromptEnabled, setMappingPromptEnabled] = useState(true);
   const [savingMappingPrompt, setSavingMappingPrompt] = useState(false);
+
+  // System-wide inbound auth toggle. When disabled, local apps connect to the
+  // gateway with no access key — used by the one-click per-workspace install.
+  const [authDisabled, setAuthDisabled] = useState(false);
+  const [savingAuthDisabled, setSavingAuthDisabled] = useState(false);
 
   // Meta-tools master switch — gates the entire `mcpmux_*` namespace.
 
@@ -242,6 +248,34 @@ export function SettingsPage() {
       setMappingPromptEnabled(prev);
     } finally {
       setSavingMappingPrompt(false);
+    }
+  };
+
+  // Load the system-wide inbound-auth toggle on mount.
+  useEffect(() => {
+    invoke<boolean>('get_gateway_auth_disabled')
+      .then(setAuthDisabled)
+      .catch((err) => console.error('Failed to load auth setting:', err));
+  }, []);
+
+  const updateAuthDisabled = async (disabled: boolean) => {
+    const prev = authDisabled;
+    setAuthDisabled(disabled);
+    setSavingAuthDisabled(true);
+    try {
+      await invoke('set_gateway_auth_disabled', { disabled });
+      success(
+        'Settings saved',
+        disabled
+          ? 'Authentication is off — local apps can connect with no access key.'
+          : 'Authentication is required again for inbound connections.'
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      error('Failed to save setting', msg);
+      setAuthDisabled(prev);
+    } finally {
+      setSavingAuthDisabled(false);
     }
   };
 
@@ -586,6 +620,41 @@ export function SettingsPage() {
                 onCheckedChange={updateMappingPrompt}
                 disabled={savingMappingPrompt}
                 data-testid="workspace-mapping-prompt-switch"
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Security Section */}
+        <Card data-testid="settings-security-section">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <ShieldOff className="h-5 w-5" />
+              Security
+            </CardTitle>
+            <CardDescription>
+              How McpMux authenticates apps connecting to the local gateway.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex min-w-0 flex-1 items-start gap-3">
+                <ShieldOff className="mt-0.5 h-5 w-5 flex-shrink-0 text-[rgb(var(--muted))]" />
+                <div>
+                  <label className="text-sm font-medium">Disable authentication</label>
+                  <p className="mt-1 text-xs text-[rgb(var(--muted))]">
+                    Let local apps connect to the gateway with no access key — just the URL and a
+                    workspace header. Makes one-click per-workspace setup trivial. The gateway only
+                    listens on localhost, but any app on this machine can then reach it. Leave on
+                    unless you want the simplest setup.
+                  </p>
+                </div>
+              </div>
+              <Switch
+                checked={authDisabled}
+                onCheckedChange={updateAuthDisabled}
+                disabled={savingAuthDisabled}
+                data-testid="disable-auth-switch"
               />
             </div>
           </CardContent>

--- a/apps/desktop/src/features/workspaces/WorkspaceBindingSheet.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspaceBindingSheet.tsx
@@ -245,6 +245,15 @@ export function WorkspaceBindingSheet() {
               </div>
             </div>
           </div>
+
+          {/* Self-intro: point at the per-workspace installer so apps that
+              don't report this folder (e.g. Cursor) still route here. */}
+          <p className="mt-3 text-xs text-[rgb(var(--muted))]" data-testid="binding-sheet-install-hint">
+            Tip: app not routing here? In the Workspaces tab, open this folder and{' '}
+            <span className="font-medium text-[rgb(var(--foreground))]">Connect apps to this folder</span>{' '}
+            to write its config with a workspace header — it works even when the app doesn&apos;t
+            report the folder.
+          </p>
         </div>
 
         <div className="flex-1 overflow-y-auto px-8 pb-6 space-y-6">

--- a/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useState } from 'react';
 import { Check, Copy, Download, Loader2, ShieldCheck, ShieldOff, AlertCircle } from 'lucide-react';
 import { Button } from '@mcpmux/ui';
 import { getGatewayStatus } from '@/lib/api/gateway';
+import { useNavigateTo } from '@/stores';
 import {
   generateWorkspaceConfigSnippet,
   getGatewayAuthDisabled,
   installWorkspaceMcpConfig,
   listWorkspaceInstallClients,
-  setGatewayAuthDisabled,
   type WorkspaceInstallClient,
   type WorkspaceInstallResult,
 } from '@/lib/api/workspaceInstall';
@@ -62,7 +62,7 @@ export function WorkspaceInstallPanel({ workspaceRoot }: { workspaceRoot: string
   const [results, setResults] = useState<WorkspaceInstallResult[] | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [togglingAuth, setTogglingAuth] = useState(false);
+  const navigateTo = useNavigateTo();
 
   useEffect(() => {
     let cancelled = false;
@@ -146,18 +146,6 @@ export function WorkspaceInstallPanel({ workspaceRoot }: { workspaceRoot: string
     }
   };
 
-  const handleDisableAuth = async () => {
-    setTogglingAuth(true);
-    try {
-      const v = await setGatewayAuthDisabled(true);
-      setAuthDisabled(v);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setTogglingAuth(false);
-    }
-  };
-
   return (
     <div className="space-y-4" data-testid="workspace-install-panel">
       <p className="text-sm text-[rgb(var(--muted))]">
@@ -179,23 +167,18 @@ export function WorkspaceInstallPanel({ workspaceRoot }: { workspaceRoot: string
               Apps will need an access key to connect.
             </p>
             <p className="mt-0.5 text-amber-700 dark:text-amber-400">
-              For zero-config setup, disable system-wide authentication — apps then connect with
-              just the URL and this workspace header.
+              Authentication is an application-wide setting. For zero-config setup, turn it off in
+              Settings → Security — apps then connect with just the URL and this workspace header.
             </p>
             <Button
               variant="secondary"
               size="sm"
               className="mt-2 h-7 text-xs"
-              disabled={togglingAuth}
-              onClick={handleDisableAuth}
-              data-testid="workspace-install-disable-auth"
+              onClick={() => navigateTo('settings')}
+              data-testid="workspace-install-open-auth-settings"
             >
-              {togglingAuth ? (
-                <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
-              ) : (
-                <ShieldOff className="mr-1.5 h-3 w-3" />
-              )}
-              Disable authentication
+              <ShieldOff className="mr-1.5 h-3 w-3" />
+              Open Settings
             </Button>
           </div>
         </div>

--- a/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Check, Copy, Download, Loader2, ShieldCheck, ShieldOff, AlertCircle } from 'lucide-react';
+import { Button } from '@mcpmux/ui';
+import { getGatewayStatus } from '@/lib/api/gateway';
+import {
+  generateWorkspaceConfigSnippet,
+  getGatewayAuthDisabled,
+  installWorkspaceMcpConfig,
+  listWorkspaceInstallClients,
+  setGatewayAuthDisabled,
+  type WorkspaceInstallClient,
+  type WorkspaceInstallResult,
+} from '@/lib/api/workspaceInstall';
+
+/** Clients selected by default — the most common three. */
+const DEFAULT_SELECTED = ['cursor', 'claude-code', 'vscode'];
+
+/**
+ * "Connect apps to this folder" — writes (or extends) project-local MCP configs
+ * inside `workspaceRoot`, injecting `X-Mcpmux-Workspace: <folder path>` so the
+ * gateway routes those apps to this folder's binding deterministically, even
+ * when the client doesn't report MCP roots. Also surfaces (and can flip) the
+ * system-wide auth toggle inline, since disabling it makes the config a pure
+ * URL + header with no access key.
+ */
+export function WorkspaceInstallPanel({ workspaceRoot }: { workspaceRoot: string }) {
+  const [clients, setClients] = useState<WorkspaceInstallClient[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(DEFAULT_SELECTED));
+  const [mcpUrl, setMcpUrl] = useState<string | null>(null);
+  const [authDisabled, setAuthDisabled] = useState<boolean | null>(null);
+  const [installing, setInstalling] = useState(false);
+  const [results, setResults] = useState<WorkspaceInstallResult[] | null>(null);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [togglingAuth, setTogglingAuth] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [list, status, disabled] = await Promise.all([
+          listWorkspaceInstallClients(),
+          getGatewayStatus().catch(() => ({ running: false, url: null as string | null })),
+          getGatewayAuthDisabled().catch(() => false),
+        ]);
+        if (cancelled) return;
+        setClients(list);
+        setAuthDisabled(disabled);
+        setMcpUrl(status.url ? `${status.url}/mcp` : null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const toggleClient = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+    setResults(null);
+  };
+
+  const handleCopy = useCallback(
+    async (clientId: string) => {
+      if (!mcpUrl) return;
+      try {
+        const snip = await generateWorkspaceConfigSnippet({
+          client: clientId,
+          serverUrl: mcpUrl,
+          workspaceRoot,
+        });
+        await navigator.clipboard.writeText(snip.content);
+        setCopiedId(clientId);
+        setTimeout(() => setCopiedId((c) => (c === clientId ? null : c)), 1500);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [mcpUrl, workspaceRoot]
+  );
+
+  const handleInstall = async () => {
+    if (!mcpUrl || selected.size === 0) return;
+    setInstalling(true);
+    setError(null);
+    setResults(null);
+    try {
+      const res = await installWorkspaceMcpConfig({
+        workspaceRoot,
+        serverUrl: mcpUrl,
+        clients: Array.from(selected),
+      });
+      setResults(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  const handleDisableAuth = async () => {
+    setTogglingAuth(true);
+    try {
+      const v = await setGatewayAuthDisabled(true);
+      setAuthDisabled(v);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setTogglingAuth(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4" data-testid="workspace-install-panel">
+      <p className="text-sm text-[rgb(var(--muted))]">
+        Drop McpMux into this folder&apos;s MCP config for the apps you use. Each gets a{' '}
+        <code className="text-xs">X-Mcpmux-Workspace</code> header set to this path, so it routes
+        here automatically — even apps that don&apos;t report the folder (like Cursor).
+      </p>
+
+      {/* Self-introductory auth nudge — disabling auth makes the written config
+          a pure URL + header with no access key to manage. */}
+      {authDisabled === false && (
+        <div
+          className="flex items-start gap-2.5 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs dark:border-amber-800/60 dark:bg-amber-900/20"
+          data-testid="workspace-install-auth-nudge"
+        >
+          <ShieldOff className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+          <div className="min-w-0 flex-1">
+            <p className="font-medium text-amber-800 dark:text-amber-300">
+              Apps will need an access key to connect.
+            </p>
+            <p className="mt-0.5 text-amber-700 dark:text-amber-400">
+              For zero-config setup, disable system-wide authentication — apps then connect with
+              just the URL and this workspace header.
+            </p>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="mt-2 h-7 text-xs"
+              disabled={togglingAuth}
+              onClick={handleDisableAuth}
+              data-testid="workspace-install-disable-auth"
+            >
+              {togglingAuth ? (
+                <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
+              ) : (
+                <ShieldOff className="mr-1.5 h-3 w-3" />
+              )}
+              Disable authentication
+            </Button>
+          </div>
+        </div>
+      )}
+      {authDisabled === true && (
+        <div className="flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-2.5 text-xs text-emerald-700 dark:border-emerald-800/60 dark:bg-emerald-900/20 dark:text-emerald-300">
+          <ShieldCheck className="h-4 w-4 flex-shrink-0" />
+          Authentication is off — apps connect with just the URL and workspace header.
+        </div>
+      )}
+
+      {/* Client checklist with per-row copy. */}
+      <div className="overflow-hidden rounded-lg border border-[rgb(var(--border))]">
+        {clients.map((c, i) => {
+          const checked = selected.has(c.id);
+          return (
+            <label
+              key={c.id}
+              className={`flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-[rgb(var(--surface-hover))] ${
+                i > 0 ? 'border-t border-[rgb(var(--border-subtle))]' : ''
+              }`}
+              data-testid={`workspace-install-client-${c.id}`}
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={() => toggleClient(c.id)}
+                className="h-4 w-4 flex-shrink-0 accent-primary-500"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium text-[rgb(var(--foreground))]">{c.label}</div>
+                <div className="truncate font-mono text-[11px] text-[rgb(var(--muted))]">
+                  {c.config_path}
+                </div>
+              </div>
+              <button
+                type="button"
+                title="Copy this client's config"
+                disabled={!mcpUrl}
+                onClick={(e) => {
+                  e.preventDefault();
+                  void handleCopy(c.id);
+                }}
+                className="flex-shrink-0 rounded-md p-1.5 text-[rgb(var(--muted))] transition-colors hover:bg-[rgb(var(--surface))] hover:text-[rgb(var(--foreground))] disabled:opacity-40"
+                data-testid={`workspace-install-copy-${c.id}`}
+              >
+                {copiedId === c.id ? (
+                  <Check className="h-3.5 w-3.5 text-green-600" />
+                ) : (
+                  <Copy className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </label>
+          );
+        })}
+      </div>
+
+      {error && (
+        <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-2.5 text-xs text-red-600 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {results && (
+        <div className="space-y-1.5" data-testid="workspace-install-results">
+          {results.map((r) => (
+            <div
+              key={r.client}
+              className="flex items-center gap-2 rounded-md border border-[rgb(var(--border-subtle))] bg-[rgb(var(--surface))] px-2.5 py-1.5 text-xs"
+            >
+              {r.action === 'error' ? (
+                <AlertCircle className="h-3.5 w-3.5 flex-shrink-0 text-red-500" />
+              ) : (
+                <Check className="h-3.5 w-3.5 flex-shrink-0 text-green-600" />
+              )}
+              <span className="font-medium">{r.label}</span>
+              <span className="text-[rgb(var(--muted))]">
+                {r.action === 'error' ? r.error : `${r.action} ${r.path}`}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Button
+        variant="primary"
+        size="sm"
+        className="w-full"
+        disabled={installing || selected.size === 0 || !mcpUrl}
+        onClick={handleInstall}
+        data-testid="workspace-install-button"
+      >
+        {installing ? (
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        ) : (
+          <Download className="mr-2 h-4 w-4" />
+        )}
+        {mcpUrl
+          ? `Install into ${selected.size} app${selected.size === 1 ? '' : 's'}`
+          : 'Start the gateway to install'}
+      </Button>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
@@ -164,11 +164,12 @@ export function WorkspaceInstallPanel({ workspaceRoot }: { workspaceRoot: string
           <ShieldOff className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
           <div className="min-w-0 flex-1">
             <p className="font-medium text-amber-800 dark:text-amber-300">
-              Apps will need an access key to connect.
+              You&apos;ll enable and authenticate this app once for it to work.
             </p>
             <p className="mt-0.5 text-amber-700 dark:text-amber-400">
-              Authentication is an application-wide setting. For zero-config setup, turn it off in
-              Settings → Security — apps then connect with just the URL and this workspace header.
+              With authentication on, you approve and sign the app in a single time, then it
+              connects. The client authentication requirement can be disabled in Settings → Security
+              — apps then connect with just the URL and this workspace header.
             </p>
             <Button
               variant="secondary"

--- a/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
@@ -163,13 +163,9 @@ export function WorkspaceInstallPanel({ workspaceRoot }: { workspaceRoot: string
         >
           <ShieldOff className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
           <div className="min-w-0 flex-1">
-            <p className="font-medium text-amber-800 dark:text-amber-300">
-              You&apos;ll enable and authenticate this app once for it to work.
-            </p>
-            <p className="mt-0.5 text-amber-700 dark:text-amber-400">
-              With authentication on, you approve and sign the app in a single time, then it
-              connects. The client authentication requirement can be disabled in Settings → Security
-              — apps then connect with just the URL and this workspace header.
+            <p className="text-amber-800 dark:text-amber-300">
+              Enable and authenticate this app once to connect — or disable the requirement in
+              Settings.
             </p>
             <Button
               variant="secondary"

--- a/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
@@ -149,9 +149,9 @@ export function WorkspaceInstallPanel({ workspaceRoot }: { workspaceRoot: string
   return (
     <div className="space-y-4" data-testid="workspace-install-panel">
       <p className="text-sm text-[rgb(var(--muted))]">
-        Drop McpMux into this folder&apos;s MCP config for the apps you use. Each gets a{' '}
+        Add McpMux to this folder&apos;s MCP config for the apps you use. Each gets an{' '}
         <code className="text-xs">X-Mcpmux-Workspace</code> header set to this path, so it routes
-        here automatically — even apps that don&apos;t report the folder (like Cursor).
+        here automatically — even apps that don&apos;t report the folder.
       </p>
 
       {/* Self-introductory auth nudge — disabling auth makes the written config

--- a/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Check, Copy, Download, Loader2, ShieldCheck, ShieldOff, AlertCircle } from 'lucide-react';
 import { Button } from '@mcpmux/ui';
 import { getGatewayStatus } from '@/lib/api/gateway';
-import { useNavigateTo } from '@/stores';
+import { useNavigateTo, useSetPendingSettingsSection } from '@/stores';
 import {
   generateWorkspaceConfigSnippet,
   getGatewayAuthDisabled,
@@ -63,6 +63,7 @@ export function WorkspaceInstallPanel({ workspaceRoot }: { workspaceRoot: string
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const navigateTo = useNavigateTo();
+  const setPendingSettingsSection = useSetPendingSettingsSection();
 
   useEffect(() => {
     let cancelled = false;
@@ -171,7 +172,10 @@ export function WorkspaceInstallPanel({ workspaceRoot }: { workspaceRoot: string
               variant="secondary"
               size="sm"
               className="mt-2 h-7 text-xs"
-              onClick={() => navigateTo('settings')}
+              onClick={() => {
+                setPendingSettingsSection('security');
+                navigateTo('settings');
+              }}
               data-testid="workspace-install-open-auth-settings"
             >
               <ShieldOff className="mr-1.5 h-3 w-3" />

--- a/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspaceInstallPanel.tsx
@@ -12,8 +12,34 @@ import {
   type WorkspaceInstallResult,
 } from '@/lib/api/workspaceInstall';
 
-/** Clients selected by default — the most common three. */
+/** Clients selected by default the first time, before the user picks. */
 const DEFAULT_SELECTED = ['cursor', 'claude-code', 'vscode'];
+
+/** Where the last client selection is remembered across folders/sessions. */
+const SELECTION_STORAGE_KEY = 'mcpmux:workspace-install-clients';
+
+/** Read the remembered client selection, or null when none/invalid. */
+function loadSavedSelection(): Set<string> | null {
+  try {
+    const raw = localStorage.getItem(SELECTION_STORAGE_KEY);
+    if (!raw) return null;
+    const arr: unknown = JSON.parse(raw);
+    if (Array.isArray(arr) && arr.every((x) => typeof x === 'string')) {
+      return new Set(arr as string[]);
+    }
+  } catch {
+    /* ignore corrupt / unavailable storage */
+  }
+  return null;
+}
+
+function saveSelection(ids: Set<string>) {
+  try {
+    localStorage.setItem(SELECTION_STORAGE_KEY, JSON.stringify(Array.from(ids)));
+  } catch {
+    /* ignore */
+  }
+}
 
 /**
  * "Connect apps to this folder" — writes (or extends) project-local MCP configs
@@ -25,7 +51,11 @@ const DEFAULT_SELECTED = ['cursor', 'claude-code', 'vscode'];
  */
 export function WorkspaceInstallPanel({ workspaceRoot }: { workspaceRoot: string }) {
   const [clients, setClients] = useState<WorkspaceInstallClient[]>([]);
-  const [selected, setSelected] = useState<Set<string>>(() => new Set(DEFAULT_SELECTED));
+  // Restore the user's last selection (remembered across folders); fall back to
+  // the common-three default the first time.
+  const [selected, setSelected] = useState<Set<string>>(
+    () => loadSavedSelection() ?? new Set(DEFAULT_SELECTED)
+  );
   const [mcpUrl, setMcpUrl] = useState<string | null>(null);
   const [authDisabled, setAuthDisabled] = useState<boolean | null>(null);
   const [installing, setInstalling] = useState(false);
@@ -45,6 +75,13 @@ export function WorkspaceInstallPanel({ workspaceRoot }: { workspaceRoot: string
         ]);
         if (cancelled) return;
         setClients(list);
+        // Drop any remembered ids that aren't supported anymore; if that
+        // leaves nothing, fall back to the defaults that do exist.
+        setSelected((prev) => {
+          const known = new Set(list.map((c) => c.id));
+          const pruned = [...prev].filter((id) => known.has(id));
+          return new Set(pruned.length ? pruned : DEFAULT_SELECTED.filter((id) => known.has(id)));
+        });
         setAuthDisabled(disabled);
         setMcpUrl(status.url ? `${status.url}/mcp` : null);
       } catch (e) {
@@ -55,6 +92,11 @@ export function WorkspaceInstallPanel({ workspaceRoot }: { workspaceRoot: string
       cancelled = true;
     };
   }, []);
+
+  // Remember the selection across folders and sessions.
+  useEffect(() => {
+    saveSelection(selected);
+  }, [selected]);
 
   const toggleClient = (id: string) => {
     setSelected((prev) => {

--- a/apps/desktop/src/features/workspaces/WorkspaceSetupWizard.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspaceSetupWizard.tsx
@@ -1,0 +1,338 @@
+import { useEffect, useMemo, useState } from 'react';
+import { open as openDialog } from '@tauri-apps/plugin-dialog';
+import {
+  ArrowLeft,
+  ArrowRight,
+  Check,
+  FolderOpen,
+  FolderSearch,
+  Layers,
+  Loader2,
+  Wrench,
+  X,
+} from 'lucide-react';
+import { Button } from '@mcpmux/ui';
+import {
+  validateWorkspaceRoot,
+  type WorkspaceBinding,
+  type WorkspaceBindingInput,
+} from '@/lib/api/workspaceBindings';
+import { isStarterFeatureSet, type FeatureSet } from '@/lib/api/featureSets';
+import type { Space } from '@/lib/api/spaces';
+import { WorkspaceInstallPanel } from './WorkspaceInstallPanel';
+
+/**
+ * Guided "set up a folder" walkthrough (the create path; editing an existing
+ * mapping still uses the inspector). Three steps, by deliberate UX order:
+ *
+ *   1. Folder       — required; pick via dialog or a detected workspace.
+ *   2. Connect apps — OPTIONAL; write the per-workspace config (header) so
+ *                     apps route here even without reporting roots.
+ *   3. Tools        — defaults to the Space's Starter so Finish is one click;
+ *                     creating the binding here is what "maps" the folder.
+ *
+ * Abandoning before Finish is safe: the folder simply uses the default Starter
+ * set until it's mapped, and any installed config still points at it.
+ */
+export function WorkspaceSetupWizard({
+  spaces,
+  featureSets,
+  reportedRoots,
+  existingBindings,
+  onClose,
+  onCreate,
+  onError,
+}: {
+  spaces: Space[];
+  featureSets: FeatureSet[];
+  reportedRoots: string[];
+  existingBindings: WorkspaceBinding[];
+  onClose: () => void;
+  onCreate: (input: WorkspaceBindingInput) => Promise<WorkspaceBinding>;
+  onError: (msg: string) => void;
+}) {
+  const [step, setStep] = useState<1 | 2 | 3>(1);
+  const [folder, setFolder] = useState('');
+  const [validating, setValidating] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const defaultSpaceId = useMemo(
+    () => spaces.find((s) => s.is_default)?.id ?? spaces[0]?.id ?? '',
+    [spaces]
+  );
+  const [spaceId, setSpaceId] = useState(defaultSpaceId);
+  useEffect(() => {
+    if (!spaceId && defaultSpaceId) setSpaceId(defaultSpaceId);
+  }, [defaultSpaceId, spaceId]);
+
+  const spaceFeatureSets = useMemo(
+    () => featureSets.filter((f) => f.space_id === spaceId),
+    [featureSets, spaceId]
+  );
+  const starterId = useMemo(
+    () => spaceFeatureSets.find((f) => isStarterFeatureSet(f))?.id,
+    [spaceFeatureSets]
+  );
+  const [fsIds, setFsIds] = useState<Set<string>>(new Set());
+  // Default to the Space's Starter whenever the Space changes — keeps Finish a
+  // single click and guarantees a non-empty selection (bindings require one).
+  useEffect(() => {
+    setFsIds(starterId ? new Set([starterId]) : new Set());
+  }, [spaceId, starterId]);
+
+  // Detected folders not already mapped — quick-pick targets for step 1.
+  const boundRoots = useMemo(
+    () => new Set(existingBindings.map((b) => b.workspace_root.toLowerCase())),
+    [existingBindings]
+  );
+  const unmappedRoots = useMemo(
+    () => reportedRoots.filter((r) => !boundRoots.has(r.toLowerCase())),
+    [reportedRoots, boundRoots]
+  );
+
+  const pickFolder = async () => {
+    try {
+      const picked = await openDialog({ directory: true, multiple: false, title: 'Pick a folder' });
+      if (typeof picked !== 'string') return;
+      setValidating(true);
+      const normalized = await validateWorkspaceRoot(picked).catch(() => picked);
+      setFolder(normalized);
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setValidating(false);
+    }
+  };
+
+  const toggleFs = (id: string) =>
+    setFsIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const finish = async () => {
+    if (!folder || fsIds.size === 0 || !spaceId) return;
+    setSaving(true);
+    try {
+      await onCreate({
+        workspace_root: folder,
+        space_id: spaceId,
+        feature_set_ids: Array.from(fsIds),
+      });
+      onClose();
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+      setSaving(false);
+    }
+  };
+
+  const TITLES = ['Choose a folder', 'Connect your apps', 'Choose its tools'] as const;
+
+  return (
+    <div
+      className="fixed right-0 top-0 bottom-0 z-50 flex w-full min-w-[420px] max-w-[480px] flex-col border-l border-[rgb(var(--border))] bg-[rgb(var(--surface))] shadow-2xl animate-in slide-in-from-right duration-300"
+      data-testid="workspace-setup-wizard"
+    >
+      {/* Header + progress */}
+      <div className="flex-shrink-0 border-b border-[rgb(var(--border))] bg-[rgb(var(--surface-elevated))] p-4">
+        <div className="flex items-start justify-between">
+          <div className="min-w-0">
+            <div className="text-xs font-medium uppercase tracking-wider text-[rgb(var(--muted))]">
+              Set up a folder · Step {step} of 3
+            </div>
+            <h2 className="mt-0.5 text-lg font-bold">{TITLES[step - 1]}</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 transition-colors hover:bg-[rgb(var(--surface-hover))]"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="mt-3 flex gap-1.5">
+          {[1, 2, 3].map((n) => (
+            <div
+              key={n}
+              className={`h-1 flex-1 rounded-full ${
+                n <= step ? 'bg-primary-500' : 'bg-[rgb(var(--border))]'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        {step === 1 && (
+          <div className="space-y-4" data-testid="wizard-step-folder">
+            <p className="text-sm text-[rgb(var(--muted))]">
+              Which project folder do you want to map? Pick one, or choose a folder an app already
+              opened.
+            </p>
+            <Button variant="primary" size="sm" onClick={pickFolder} disabled={validating}>
+              {validating ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <FolderOpen className="mr-2 h-4 w-4" />
+              )}
+              Choose folder…
+            </Button>
+
+            {folder && (
+              <div className="flex items-center gap-2 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2">
+                <Check className="h-4 w-4 flex-shrink-0 text-green-600" />
+                <span className="truncate font-mono text-xs" title={folder}>
+                  {folder}
+                </span>
+              </div>
+            )}
+
+            {unmappedRoots.length > 0 && (
+              <div>
+                <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-[rgb(var(--muted))]">
+                  <FolderSearch className="h-3.5 w-3.5" />
+                  Detected workspaces
+                </div>
+                <div className="overflow-hidden rounded-lg border border-[rgb(var(--border))]">
+                  {unmappedRoots.slice(0, 6).map((r, i) => (
+                    <button
+                      key={r}
+                      type="button"
+                      onClick={() => setFolder(r)}
+                      className={`flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-[rgb(var(--surface-hover))] ${
+                        i > 0 ? 'border-t border-[rgb(var(--border-subtle))]' : ''
+                      } ${folder === r ? 'bg-primary-500/5' : ''}`}
+                    >
+                      <FolderOpen className="h-4 w-4 flex-shrink-0 text-[rgb(var(--muted))]" />
+                      <span className="truncate font-mono text-xs" title={r}>
+                        {r}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="space-y-3" data-testid="wizard-step-apps">
+            <WorkspaceInstallPanel workspaceRoot={folder} />
+            <p className="text-center text-xs text-[rgb(var(--muted))]">
+              Optional — you can connect apps later from this folder&apos;s mapping.
+            </p>
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="space-y-4" data-testid="wizard-step-tools">
+            <p className="text-sm text-[rgb(var(--muted))]">
+              Pick the tools this folder gets. The default Starter set works out of the box — change
+              it only if this folder should see something different.
+            </p>
+
+            <div>
+              <label className="mb-1 block text-xs font-medium uppercase tracking-wider text-[rgb(var(--muted))]">
+                Space
+              </label>
+              <select
+                value={spaceId}
+                onChange={(e) => setSpaceId(e.target.value)}
+                className="w-full rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2.5 text-sm"
+                data-testid="wizard-space-select"
+              >
+                {spaces.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.icon ? `${s.icon} ` : ''}
+                    {s.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-xs font-medium uppercase tracking-wider text-[rgb(var(--muted))]">
+                Feature sets
+              </label>
+              <div className="overflow-hidden rounded-xl border border-[rgb(var(--border))]">
+                {spaceFeatureSets.length === 0 ? (
+                  <div className="px-3 py-4 text-center text-xs text-[rgb(var(--muted))]">
+                    This Space has no feature sets yet.
+                  </div>
+                ) : (
+                  spaceFeatureSets.map((fs, i) => (
+                    <label
+                      key={fs.id}
+                      className={`flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-[rgb(var(--surface-hover))] ${
+                        i > 0 ? 'border-t border-[rgb(var(--border-subtle))]' : ''
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={fsIds.has(fs.id)}
+                        onChange={() => toggleFs(fs.id)}
+                        className="h-4 w-4 flex-shrink-0 accent-primary-500"
+                      />
+                      <Layers className="h-4 w-4 flex-shrink-0 text-primary-500" />
+                      <span className="min-w-0 flex-1 truncate text-sm font-medium">{fs.name}</span>
+                      {isStarterFeatureSet(fs) && (
+                        <span className="flex-shrink-0 rounded-full bg-[rgb(var(--surface))] px-1.5 text-[10px] font-semibold uppercase tracking-wider text-[rgb(var(--muted))]">
+                          Default
+                        </span>
+                      )}
+                    </label>
+                  ))
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Footer nav */}
+      <div className="flex flex-shrink-0 items-center justify-between gap-3 border-t border-[rgb(var(--border))] bg-[rgb(var(--surface-elevated))] p-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => (step === 1 ? onClose() : setStep((s) => (s - 1) as 1 | 2 | 3))}
+          data-testid="wizard-back"
+        >
+          {step === 1 ? (
+            'Cancel'
+          ) : (
+            <>
+              <ArrowLeft className="mr-1.5 h-4 w-4" />
+              Back
+            </>
+          )}
+        </Button>
+
+        {step < 3 ? (
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => setStep((s) => (s + 1) as 1 | 2 | 3)}
+            disabled={step === 1 && !folder}
+            data-testid="wizard-next"
+          >
+            {step === 2 ? 'Next' : 'Continue'}
+            <ArrowRight className="ml-1.5 h-4 w-4" />
+          </Button>
+        ) : (
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={finish}
+            disabled={saving || fsIds.size === 0 || !folder}
+            data-testid="wizard-finish"
+          >
+            {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Wrench className="mr-1.5 h-4 w-4" />}
+            Finish
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/workspaces/WorkspaceSetupWizard.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspaceSetupWizard.tsx
@@ -121,7 +121,8 @@ export function WorkspaceSetupWizard({
         space_id: spaceId,
         feature_set_ids: Array.from(fsIds),
       });
-      onClose();
+      // The parent transitions to the new mapping's inspector (which shows its
+      // effective features) — don't close here, or that view would be lost.
     } catch (e) {
       onError(e instanceof Error ? e.message : String(e));
       setSaving(false);

--- a/apps/desktop/src/features/workspaces/WorkspacesPage.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspacesPage.tsx
@@ -51,7 +51,8 @@ import {
   type FeatureSet,
 } from '@/lib/api/featureSets';
 import { WorkspaceInstallPanel } from './WorkspaceInstallPanel';
-import { useSpaces } from '@/stores';
+import { WorkspaceSetupWizard } from './WorkspaceSetupWizard';
+import { useSpaces, usePendingWorkspaceNew, useSetPendingWorkspaceNew } from '@/stores';
 import type { Space } from '@/lib/api/spaces';
 
 /**
@@ -82,6 +83,8 @@ type Selected = { mode: 'new' } | { mode: 'entry'; id: string };
 
 export function WorkspacesPage() {
   const spaces = useSpaces();
+  const pendingNew = usePendingWorkspaceNew();
+  const clearPendingNew = useSetPendingWorkspaceNew();
   const [bindings, setBindings] = useState<WorkspaceBinding[]>([]);
   const [reportedRoots, setReportedRoots] = useState<string[]>([]);
   const [featureSets, setFeatureSets] = useState<FeatureSet[]>([]);
@@ -115,6 +118,14 @@ export function WorkspacesPage() {
     setIsLoading(true);
     void loadData().finally(() => setIsLoading(false));
   }, [loadData]);
+
+  // Opened from the home "Set up a folder" CTA — launch the create walkthrough.
+  useEffect(() => {
+    if (pendingNew) {
+      setSelected({ mode: 'new' });
+      clearPendingNew(false);
+    }
+  }, [pendingNew, clearPendingNew]);
 
   // Refresh whenever something the table reflects changes outside the page:
   //   • `session-roots-changed` — a connected client newly reported a root.
@@ -446,27 +457,39 @@ export function WorkspacesPage() {
             className="fixed inset-0 bg-black/20 backdrop-blur-[2px] z-40 animate-in fade-in duration-200"
             onClick={() => setSelected(null)}
           />
-          <InspectorPanel
-            key={selectedIsNew ? 'new' : selectedEntry?.id ?? 'new'}
-            entry={selectedEntry}
-            isNew={selectedIsNew}
-            spaces={spaces}
-            featureSets={featureSets}
-            existingBindings={bindings}
-            onClose={() => setSelected(null)}
-            onSubmit={async (input) => {
-              if (selectedEntry?.binding) {
-                await handleUpdate(selectedEntry.binding.id, input);
-              } else {
-                const created = await handleCreate(input);
-                setSelected({ mode: 'entry', id: created.id });
-              }
-            }}
-            onDelete={async () => {
-              if (selectedEntry?.binding) await handleDelete(selectedEntry.binding);
-            }}
-            onError={(msg) => showError('Could not save', msg)}
-          />
+          {selectedIsNew ? (
+            <WorkspaceSetupWizard
+              spaces={spaces}
+              featureSets={featureSets}
+              reportedRoots={reportedRoots}
+              existingBindings={bindings}
+              onClose={() => setSelected(null)}
+              onCreate={handleCreate}
+              onError={(msg) => showError('Could not save', msg)}
+            />
+          ) : (
+            <InspectorPanel
+              key={selectedEntry?.id ?? 'entry'}
+              entry={selectedEntry}
+              isNew={false}
+              spaces={spaces}
+              featureSets={featureSets}
+              existingBindings={bindings}
+              onClose={() => setSelected(null)}
+              onSubmit={async (input) => {
+                if (selectedEntry?.binding) {
+                  await handleUpdate(selectedEntry.binding.id, input);
+                } else {
+                  const created = await handleCreate(input);
+                  setSelected({ mode: 'entry', id: created.id });
+                }
+              }}
+              onDelete={async () => {
+                if (selectedEntry?.binding) await handleDelete(selectedEntry.binding);
+              }}
+              onError={(msg) => showError('Could not save', msg)}
+            />
+          )}
         </>
       )}
 

--- a/apps/desktop/src/features/workspaces/WorkspacesPage.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspacesPage.tsx
@@ -464,7 +464,13 @@ export function WorkspacesPage() {
               reportedRoots={reportedRoots}
               existingBindings={bindings}
               onClose={() => setSelected(null)}
-              onCreate={handleCreate}
+              onCreate={async (input) => {
+                const created = await handleCreate(input);
+                // Land on the new mapping's inspector so its effective features
+                // are shown right after creation.
+                setSelected({ mode: 'entry', id: created.id });
+                return created;
+              }}
               onError={(msg) => showError('Could not save', msg)}
             />
           ) : (

--- a/apps/desktop/src/features/workspaces/WorkspacesPage.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspacesPage.tsx
@@ -50,6 +50,7 @@ import {
   listFeatureSets,
   type FeatureSet,
 } from '@/lib/api/featureSets';
+import { WorkspaceInstallPanel } from './WorkspaceInstallPanel';
 import { useSpaces } from '@/stores';
 import type { Space } from '@/lib/api/spaces';
 
@@ -1016,6 +1017,19 @@ function InspectorPanel({
             onSaveStatusChange={setSaveStatus}
           />
         </CollapsibleSection>
+
+        {entry && !isNew && (
+          <CollapsibleSection
+            icon={<Wrench className="h-5 w-5" />}
+            tone="primary"
+            title="Connect apps to this folder"
+            subtitle="Write the McpMux config into this folder for the apps you use, with this folder's workspace header."
+            defaultOpen={!isMapped}
+            testId="workspace-install-section"
+          >
+            <WorkspaceInstallPanel workspaceRoot={entry.root} />
+          </CollapsibleSection>
+        )}
 
         {entry && !isNew && (
           <CollapsibleSection

--- a/apps/desktop/src/lib/api/workspaceInstall.ts
+++ b/apps/desktop/src/lib/api/workspaceInstall.ts
@@ -1,0 +1,74 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/** A client the per-workspace installer can write a config for. */
+export interface WorkspaceInstallClient {
+  id: string;
+  label: string;
+  /** Project-local config path, relative to the workspace folder. */
+  config_path: string;
+}
+
+/** Result of writing one client's config. */
+export interface WorkspaceInstallResult {
+  client: string;
+  label: string;
+  path: string;
+  /** "created" | "updated" | "error". */
+  action: string;
+  backed_up: string | null;
+  error: string | null;
+}
+
+/** A copy-paste config snippet for one client. */
+export interface WorkspaceConfigSnippet {
+  client: string;
+  label: string;
+  config_path: string;
+  /** Full file content (top-level key + the McpMux entry). */
+  content: string;
+}
+
+/** The project-local clients the installer supports (Cursor, VS Code, …). */
+export async function listWorkspaceInstallClients(): Promise<WorkspaceInstallClient[]> {
+  return invoke('list_workspace_install_clients');
+}
+
+/** Generate a copy-paste config snippet for one client (writes nothing). */
+export async function generateWorkspaceConfigSnippet(args: {
+  client: string;
+  serverUrl: string;
+  workspaceRoot: string;
+  bearer?: string | null;
+}): Promise<WorkspaceConfigSnippet> {
+  return invoke('generate_workspace_config_snippet', {
+    client: args.client,
+    serverUrl: args.serverUrl,
+    workspaceRoot: args.workspaceRoot,
+    bearer: args.bearer ?? null,
+  });
+}
+
+/** Create or extend the selected clients' configs inside `workspaceRoot`. */
+export async function installWorkspaceMcpConfig(args: {
+  workspaceRoot: string;
+  serverUrl: string;
+  clients: string[];
+  bearer?: string | null;
+}): Promise<WorkspaceInstallResult[]> {
+  return invoke('install_workspace_mcp_config', {
+    workspaceRoot: args.workspaceRoot,
+    serverUrl: args.serverUrl,
+    clients: args.clients,
+    bearer: args.bearer ?? null,
+  });
+}
+
+/** Whether system-wide inbound auth is disabled (no access key required). */
+export async function getGatewayAuthDisabled(): Promise<boolean> {
+  return invoke('get_gateway_auth_disabled');
+}
+
+/** Enable/disable system-wide inbound auth. Takes effect immediately. */
+export async function setGatewayAuthDisabled(disabled: boolean): Promise<boolean> {
+  return invoke('set_gateway_auth_disabled', { disabled });
+}

--- a/apps/desktop/src/stores/appStore.ts
+++ b/apps/desktop/src/stores/appStore.ts
@@ -9,6 +9,7 @@ const initialState: AppState = {
   activeNav: 'home',
   pendingClientId: null,
   pendingSettingsSection: null,
+  pendingWorkspaceNew: false,
   sidebarCollapsed: false,
   theme: 'system',
   analyticsEnabled: true,
@@ -82,6 +83,11 @@ export const useAppStore = create<AppStore>()(
       setPendingSettingsSection: (section) =>
         set((state) => {
           state.pendingSettingsSection = section;
+        }),
+
+      setPendingWorkspaceNew: (v) =>
+        set((state) => {
+          state.pendingWorkspaceNew = v;
         }),
 
       // UI

--- a/apps/desktop/src/stores/appStore.ts
+++ b/apps/desktop/src/stores/appStore.ts
@@ -8,6 +8,7 @@ const initialState: AppState = {
   viewSpaceId: null,
   activeNav: 'home',
   pendingClientId: null,
+  pendingSettingsSection: null,
   sidebarCollapsed: false,
   theme: 'system',
   analyticsEnabled: true,
@@ -76,6 +77,11 @@ export const useAppStore = create<AppStore>()(
       setPendingClientId: (id) =>
         set((state) => {
           state.pendingClientId = id;
+        }),
+
+      setPendingSettingsSection: (section) =>
+        set((state) => {
+          state.pendingSettingsSection = section;
         }),
 
       // UI

--- a/apps/desktop/src/stores/selectors.ts
+++ b/apps/desktop/src/stores/selectors.ts
@@ -8,6 +8,10 @@ export const useActiveNav = () => useAppStore((state) => state.activeNav);
 export const useNavigateTo = () => useAppStore((state) => state.navigateTo);
 export const usePendingClientId = () => useAppStore((state) => state.pendingClientId);
 export const useSetPendingClientId = () => useAppStore((state) => state.setPendingClientId);
+export const usePendingSettingsSection = () =>
+  useAppStore((state) => state.pendingSettingsSection);
+export const useSetPendingSettingsSection = () =>
+  useAppStore((state) => state.setPendingSettingsSection);
 export const useTheme = () => useAppStore((state) => state.theme);
 export const useSidebarCollapsed = () => useAppStore((state) => state.sidebarCollapsed);
 export const useAnalyticsEnabled = () => useAppStore((state) => state.analyticsEnabled);

--- a/apps/desktop/src/stores/selectors.ts
+++ b/apps/desktop/src/stores/selectors.ts
@@ -12,6 +12,9 @@ export const usePendingSettingsSection = () =>
   useAppStore((state) => state.pendingSettingsSection);
 export const useSetPendingSettingsSection = () =>
   useAppStore((state) => state.setPendingSettingsSection);
+export const usePendingWorkspaceNew = () => useAppStore((state) => state.pendingWorkspaceNew);
+export const useSetPendingWorkspaceNew = () =>
+  useAppStore((state) => state.setPendingWorkspaceNew);
 export const useTheme = () => useAppStore((state) => state.theme);
 export const useSidebarCollapsed = () => useAppStore((state) => state.sidebarCollapsed);
 export const useAnalyticsEnabled = () => useAppStore((state) => state.analyticsEnabled);

--- a/apps/desktop/src/stores/types.ts
+++ b/apps/desktop/src/stores/types.ts
@@ -26,6 +26,8 @@ export interface AppState {
   activeNav: NavItem;
   /** Client ID to auto-select when navigating to Clients page */
   pendingClientId: string | null;
+  /** Section to scroll to + flash when navigating to Settings (e.g. 'security'). */
+  pendingSettingsSection: string | null;
 
   // UI state
   sidebarCollapsed: boolean;
@@ -50,6 +52,7 @@ export interface AppActions {
   // Navigation
   navigateTo: (nav: NavItem) => void;
   setPendingClientId: (id: string | null) => void;
+  setPendingSettingsSection: (section: string | null) => void;
 
   // UI
   toggleSidebar: () => void;

--- a/apps/desktop/src/stores/types.ts
+++ b/apps/desktop/src/stores/types.ts
@@ -28,6 +28,8 @@ export interface AppState {
   pendingClientId: string | null;
   /** Section to scroll to + flash when navigating to Settings (e.g. 'security'). */
   pendingSettingsSection: string | null;
+  /** When true, the Workspaces page opens the New-mapping walkthrough on arrival. */
+  pendingWorkspaceNew: boolean;
 
   // UI state
   sidebarCollapsed: boolean;
@@ -53,6 +55,7 @@ export interface AppActions {
   navigateTo: (nav: NavItem) => void;
   setPendingClientId: (id: string | null) => void;
   setPendingSettingsSection: (section: string | null) => void;
+  setPendingWorkspaceNew: (v: boolean) => void;
 
   // UI
   toggleSidebar: () => void;

--- a/crates/mcpmux-gateway/src/mcp/oauth_middleware.rs
+++ b/crates/mcpmux-gateway/src/mcp/oauth_middleware.rs
@@ -113,6 +113,32 @@ pub async fn mcp_oauth_middleware(
         space_id.to_string().parse().expect("valid header value"),
     );
 
+    // Pin an explicit workspace root advertised by the client via the
+    // `X-Mcpmux-Workspace` header (injected by McpMux's per-workspace client
+    // configs). It shadows the client's MCP-reported roots in the resolver, so
+    // a connection routes to its workspace binding even when the client never
+    // reports `roots` or reports a stale one (e.g. Cursor sharing one MCP host
+    // across windows). Unlike client/space id above, this header is
+    // client-asserted — the same trust model as MCP roots: any approved local
+    // client can claim any binding (see FeatureSetResolver trust model). Keyed
+    // by the `mcp-session-id` the client echoes on every post-initialize
+    // request (the same key the handler stores reported roots under).
+    let pin = {
+        let headers = request.headers();
+        let sid = headers
+            .get("mcp-session-id")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let ws = headers
+            .get("x-mcpmux-workspace")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        sid.zip(ws)
+    };
+    if let Some((sid, ws)) = pin {
+        services.session_roots.set_pinned(&sid, &ws);
+    }
+
     // Extract MCP method from body if POST
     let mcp_method = if request.method() == axum::http::Method::POST {
         use axum::body::to_bytes;

--- a/crates/mcpmux-gateway/src/mcp/oauth_middleware.rs
+++ b/crates/mcpmux-gateway/src/mcp/oauth_middleware.rs
@@ -18,6 +18,12 @@ use crate::auth::validate_token;
 use crate::logging::TraceContext;
 use crate::server::ServiceContainer;
 
+/// Synthetic client identity used when system-wide inbound auth is disabled and
+/// a connection arrives without a (valid) Bearer token. Routing still prefers
+/// the `X-Mcpmux-Workspace` header → binding; this id only feeds the rootless
+/// `client_grants` fallback (which finds none) → Space default.
+const ANONYMOUS_CLIENT_ID: &str = "mcpmux-anonymous";
+
 /// OAuth middleware for MCP endpoints using rmcp
 ///
 /// Extracts Bearer token → Verifies JWT → Resolves space → Injects OAuthContext
@@ -38,75 +44,99 @@ pub async fn mcp_oauth_middleware(
         .map(|ctx| ctx.trace_id.clone())
         .unwrap_or_else(|| "??????".to_string());
 
-    // Extract Authorization header
+    // System-wide inbound auth can be disabled (localhost-only convenience):
+    // when off, a connection is accepted without a Bearer token and routed by
+    // the workspace header / default space. A valid token is still honored when
+    // present, so flipping the setting never breaks an already-configured
+    // client. Default is auth-required.
+    let require_auth = !services.gateway_state.read().await.auth_disabled();
+
     let auth_header = request
         .headers()
         .get("authorization")
-        .and_then(|v| v.to_str().ok());
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned);
+    let token = auth_header
+        .as_deref()
+        .and_then(|v| v.strip_prefix("Bearer "));
 
-    let Some(auth_value) = auth_header else {
-        warn!(trace_id = %trace_id, "Missing Authorization header");
-        return unauthorized_response("Missing Authorization header");
-    };
-
-    // Extract Bearer token
-    let token = match auth_value.strip_prefix("Bearer ") {
-        Some(t) => t,
-        None => {
-            warn!(trace_id = %trace_id, "Authorization header must use Bearer scheme");
-            return unauthorized_response("Authorization header must use Bearer scheme");
+    // Verify the Bearer token whenever one is present.
+    let claims = match token {
+        Some(token) => {
+            let jwt_secret = {
+                let state = services.gateway_state.read().await;
+                state.get_jwt_secret().map(|s| s.to_vec())
+            };
+            match jwt_secret {
+                Some(secret) => validate_token(token, &secret),
+                None => {
+                    warn!(trace_id = %trace_id, "JWT secret not configured");
+                    None
+                }
+            }
         }
+        None => None,
     };
 
-    // Verify JWT and extract claims
-    let jwt_secret = {
-        let state = services.gateway_state.read().await;
-        match state.get_jwt_secret() {
-            Some(secret) => secret.to_vec(),
-            None => {
-                warn!(trace_id = %trace_id, "JWT secret not configured");
+    // Resolve (client_id, space_id) from the token, or — when auth is disabled
+    // — fall back to an anonymous identity on the default space.
+    let (client_id, space_id) = if let Some(claims) = claims {
+        match services
+            .space_resolver_service
+            .resolve_space_for_client(&claims.client_id)
+            .await
+        {
+            Ok(id) => (claims.client_id, id),
+            Err(e) => {
+                warn!(
+                    trace_id = %trace_id,
+                    client_id = %claims.client_id,
+                    "Failed to resolve space: {}", e
+                );
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    "Server not configured for authentication",
+                    format!("Failed to resolve space: {}", e),
+                )
+                    .into_response();
+            }
+        }
+    } else if require_auth {
+        // No valid token and auth is required → 401 with the specific reason.
+        let msg = match auth_header.as_deref() {
+            None => "Missing Authorization header",
+            Some(v) if !v.starts_with("Bearer ") => "Authorization header must use Bearer scheme",
+            _ => "Invalid token",
+        };
+        warn!(trace_id = %trace_id, "{}", msg);
+        return unauthorized_response(msg);
+    } else {
+        // Auth disabled → accept anonymously on the default space. Routing
+        // still prefers the workspace header (pinned below) → binding.
+        match services.dependencies.space_repo.get_default().await {
+            Ok(Some(space)) => (ANONYMOUS_CLIENT_ID.to_string(), space.id),
+            Ok(None) => {
+                warn!(trace_id = %trace_id, "Auth disabled but no default space configured");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "No default space configured",
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                warn!(trace_id = %trace_id, "Failed to resolve default space: {}", e);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to resolve default space: {}", e),
                 )
                     .into_response();
             }
         }
     };
 
-    let claims = match validate_token(token, &jwt_secret) {
-        Some(claims) => claims,
-        None => {
-            warn!(trace_id = %trace_id, "Token verification failed");
-            return unauthorized_response("Invalid token");
-        }
-    };
-
-    // Resolve space for this client
-    let space_id = match services
-        .space_resolver_service
-        .resolve_space_for_client(&claims.client_id)
-        .await
-    {
-        Ok(id) => id,
-        Err(e) => {
-            warn!(
-                trace_id = %trace_id,
-                client_id = %claims.client_id,
-                "Failed to resolve space: {}", e
-            );
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to resolve space: {}", e),
-            )
-                .into_response();
-        }
-    };
-
     // Inject OAuth context via custom headers (rmcp will preserve these)
     request.headers_mut().insert(
         "x-mcpmux-client-id",
-        claims.client_id.parse().expect("valid header value"),
+        client_id.parse().expect("valid header value"),
     );
     request.headers_mut().insert(
         "x-mcpmux-space-id",
@@ -152,7 +182,7 @@ pub async fn mcp_oauth_middleware(
                 // Log single consolidated entry line
                 info!(
                     trace_id = %trace_id,
-                    client = %&claims.client_id[..claims.client_id.len().min(12)],
+                    client = %&client_id[..client_id.len().min(12)],
                     space = %&space_id.to_string()[..8],
                     method = method.as_deref().unwrap_or("-"),
                     "→ MCP"
@@ -185,7 +215,7 @@ pub async fn mcp_oauth_middleware(
         warn!(
             trace_id = %trace_id,
             status = %status,
-            client = %claims.client_id,
+            client = %client_id,
             method = mcp_method.as_deref().unwrap_or("-"),
             "← MCP error"
         );

--- a/crates/mcpmux-gateway/src/server/state.rs
+++ b/crates/mcpmux-gateway/src/server/state.rs
@@ -61,6 +61,11 @@ pub struct GatewayState {
     client_metadata_service: Option<Arc<ClientMetadataService>>,
     /// Unified event broadcaster (UI subscribes to receive all domain events)
     domain_event_tx: broadcast::Sender<DomainEvent>,
+    /// When true, inbound MCP connections are accepted WITHOUT a Bearer token
+    /// (localhost-only convenience). Default false (auth required). Seeded from
+    /// the `gateway.auth_disabled` app setting at startup and flipped live by
+    /// the desktop toggle. A valid token is still honored when present.
+    auth_disabled: bool,
 }
 
 impl GatewayState {
@@ -77,6 +82,7 @@ impl GatewayState {
             inbound_client_repository: None,
             client_metadata_service: None,
             domain_event_tx,
+            auth_disabled: false,
         }
     }
 
@@ -84,6 +90,24 @@ impl GatewayState {
     pub fn set_base_url(&mut self, base_url: String) {
         info!("[State] Base URL configured: {}", base_url);
         self.base_url = base_url;
+    }
+
+    /// Whether inbound MCP auth is disabled — connections may be accepted
+    /// without a Bearer token. See [`Self::auth_disabled`] field docs.
+    pub fn auth_disabled(&self) -> bool {
+        self.auth_disabled
+    }
+
+    /// Enable/disable system-wide inbound auth. Called at startup (seed from
+    /// settings) and live from the desktop toggle.
+    pub fn set_auth_disabled(&mut self, disabled: bool) {
+        if self.auth_disabled != disabled {
+            info!(
+                "[State] Inbound auth {}",
+                if disabled { "DISABLED" } else { "enabled" }
+            );
+        }
+        self.auth_disabled = disabled;
     }
 
     /// Subscribe to domain events (new unified channel)
@@ -263,5 +287,21 @@ impl Default for GatewayState {
     fn default() -> Self {
         let (domain_event_tx, _) = broadcast::channel(256);
         Self::new(domain_event_tx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_disabled_defaults_off_and_toggles() {
+        let mut state = GatewayState::default();
+        // Secure default: auth is required (not disabled).
+        assert!(!state.auth_disabled());
+        state.set_auth_disabled(true);
+        assert!(state.auth_disabled());
+        state.set_auth_disabled(false);
+        assert!(!state.auth_disabled());
     }
 }

--- a/crates/mcpmux-gateway/src/services/feature_set_resolver.rs
+++ b/crates/mcpmux-gateway/src/services/feature_set_resolver.rs
@@ -76,6 +76,19 @@
 //!
 //! Roots-capable detection is stamped at `on_initialized` time into
 //! [`SessionRootsRegistry::set_roots_capable`].
+//!
+//! # Explicit workspace root via the `X-Mcpmux-Workspace` header
+//!
+//! A connection can carry an explicit workspace root in the
+//! `X-Mcpmux-Workspace` HTTP header, injected by McpMux's per-workspace client
+//! configs. The OAuth middleware pins it into
+//! [`SessionRootsRegistry::set_pinned`], where it **shadows** the client's
+//! probed MCP roots in [`SessionRootsRegistry::get`]. Because this resolver
+//! reads roots exclusively through `get`, a pinned root flows through Tier 1
+//! unchanged — an exact binding match, else the Space default — with no extra
+//! tier or parameter. This is the deterministic path for clients that don't
+//! report `roots` reliably (e.g. Cursor multiplexing one MCP host across
+//! windows): the header always wins over a stale or absent reported root.
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/mcpmux-gateway/src/services/session_roots.rs
+++ b/crates/mcpmux-gateway/src/services/session_roots.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use mcpmux_core::normalize_workspace_root;
+use tracing::debug;
 
 /// Thread-safe registry mapping `mcp-session-id` to the caller's reported
 /// workspace roots, plus the most recently resolved feature-set id so the
@@ -66,6 +67,18 @@ pub struct SessionRootsRegistry {
     /// roots-capable client from flashing the default FeatureSet and then
     /// flipping to its mapped one the instant its root lands.
     first_seen: DashMap<String, Instant>,
+    /// `session_id -> explicit workspace root pinned via the
+    /// `X-Mcpmux-Workspace` HTTP header`.
+    ///
+    /// McpMux's per-workspace client configs inject that header with the
+    /// folder's path, so a connection routes to its workspace binding even
+    /// when the client never reports MCP `roots` or reports a stale one (e.g.
+    /// Cursor sharing a single MCP host across windows, with
+    /// `roots.listChanged = false`). A pinned root is **authoritative**: it
+    /// shadows the probed [`Self::map`] roots in [`Self::get`], so the
+    /// resolver, the on-demand probe skip, and the prompt-root derivation all
+    /// honor the header with no special-casing. Already normalized on insert.
+    pinned: DashMap<String, String>,
 }
 
 impl SessionRootsRegistry {
@@ -77,6 +90,7 @@ impl SessionRootsRegistry {
             last_probe: DashMap::new(),
             probe_lock: DashMap::new(),
             first_seen: DashMap::new(),
+            pinned: DashMap::new(),
         })
     }
 
@@ -155,8 +169,51 @@ impl SessionRootsRegistry {
     }
 
     /// Retrieve the (already-normalized) roots for a session, if any.
+    ///
+    /// An explicit root pinned via the `X-Mcpmux-Workspace` header
+    /// ([`Self::set_pinned`]) takes precedence over — and entirely shadows —
+    /// the client's probed MCP roots. That single seam is what makes the
+    /// header authoritative everywhere `get` is consulted (resolver Tier 1,
+    /// the probe early-return, prompt-root derivation) without threading the
+    /// header through any of those call paths.
     pub fn get(&self, session_id: &str) -> Option<Vec<String>> {
+        if let Some(pinned) = self.pinned.get(session_id) {
+            return Some(vec![pinned.clone()]);
+        }
         self.map.get(session_id).map(|v| v.clone())
+    }
+
+    /// Pin an explicit workspace root for a session, sourced from the
+    /// `X-Mcpmux-Workspace` HTTP header. `raw_root` is a filesystem path or
+    /// `file://` URI; it's normalized like every other root before storage.
+    /// A value that normalizes to empty is ignored (no pin), so a malformed
+    /// header falls back to the client's reported roots rather than denying.
+    /// Cheap to call on the request hot path: redundant writes (same
+    /// normalized value already pinned) are skipped to avoid shard churn.
+    pub fn set_pinned(&self, session_id: &str, raw_root: &str) {
+        let normalized = normalize_workspace_root(raw_root);
+        if normalized.is_empty() {
+            return;
+        }
+        if self
+            .pinned
+            .get(session_id)
+            .is_some_and(|v| *v == normalized)
+        {
+            return;
+        }
+        debug!(
+            %session_id,
+            workspace_root = %normalized,
+            "[SessionRoots] pinned explicit workspace root from X-Mcpmux-Workspace header",
+        );
+        self.pinned.insert(session_id.to_string(), normalized);
+    }
+
+    /// The explicit workspace root pinned for a session via the header, if any
+    /// (already normalized).
+    pub fn get_pinned(&self, session_id: &str) -> Option<String> {
+        self.pinned.get(session_id).map(|v| v.clone())
     }
 
     /// Drop a session's roots — call on client disconnect.
@@ -167,6 +224,7 @@ impl SessionRootsRegistry {
         self.last_probe.remove(session_id);
         self.probe_lock.remove(session_id);
         self.first_seen.remove(session_id);
+        self.pinned.remove(session_id);
     }
 
     /// Compare-and-set the session's resolved feature-set id. Returns `true`
@@ -309,6 +367,56 @@ mod tests {
         assert_eq!(reg.len(), 1);
         reg.remove("sess-1");
         assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn test_pinned_root_shadows_reported_roots() {
+        let reg = SessionRootsRegistry::default();
+        #[cfg(windows)]
+        let (reported, pin_in, pin_norm) = (
+            "file:///D:/reported/",
+            "D:\\Pinned\\Path",
+            "d:\\pinned\\path",
+        );
+        #[cfg(not(windows))]
+        let (reported, pin_in, pin_norm) = (
+            "file:///home/u/reported/",
+            "/home/u/Pinned",
+            "/home/u/Pinned",
+        );
+
+        reg.set("sess-1", [reported]);
+        reg.set_pinned("sess-1", pin_in);
+
+        // The pinned (header) root entirely shadows the probed root.
+        assert_eq!(reg.get("sess-1"), Some(vec![pin_norm.to_string()]));
+        assert_eq!(reg.get_pinned("sess-1"), Some(pin_norm.to_string()));
+    }
+
+    #[test]
+    fn test_set_pinned_ignores_empty_and_normalizes() {
+        let reg = SessionRootsRegistry::default();
+        // Whitespace/garbage that normalizes to empty leaves no pin, so a
+        // malformed header falls back to reported roots rather than denying.
+        reg.set_pinned("sess-1", "   ");
+        assert!(reg.get_pinned("sess-1").is_none());
+
+        #[cfg(windows)]
+        let (pin_in, pin_norm) = ("file:///D:/Foo/", "d:\\foo");
+        #[cfg(not(windows))]
+        let (pin_in, pin_norm) = ("file:///home/u/Foo/", "/home/u/Foo");
+        reg.set_pinned("sess-1", pin_in);
+        assert_eq!(reg.get_pinned("sess-1"), Some(pin_norm.to_string()));
+    }
+
+    #[test]
+    fn test_remove_clears_pinned() {
+        let reg = SessionRootsRegistry::default();
+        reg.set_pinned("sess-1", "/p");
+        assert!(reg.get_pinned("sess-1").is_some());
+        reg.remove("sess-1");
+        assert!(reg.get_pinned("sess-1").is_none());
+        assert!(reg.get("sess-1").is_none());
     }
 
     #[test]

--- a/docs/manual/workspace-header-routing.md
+++ b/docs/manual/workspace-header-routing.md
@@ -1,0 +1,111 @@
+# Manual test — per-workspace routing via `X-Mcpmux-Workspace`
+
+Covers the feature added on `feat/workspace-header-mapping`:
+
+1. Deterministic per-workspace routing via the `X-Mcpmux-Workspace` header
+   (fixes Cursor reporting the wrong/another workspace root).
+2. One-click per-workspace client config install.
+3. System-wide "disable authentication" toggle.
+
+Automated coverage exists for the resolver, the config writer, the gateway
+state toggle, and the install panel (see _Automated tests_ at the end). The
+steps below verify the end-to-end behavior that automation can't — a real
+client connecting through the gateway.
+
+## Prerequisites
+
+- `pnpm dev` (desktop app + gateway) running.
+- Two real workspace folders, e.g. `D:\proj\alpha` and `D:\proj\beta`.
+- Cursor installed (the client this feature primarily targets). VS Code /
+  Claude Code are good controls — they already route correctly via roots.
+
+---
+
+## A. Header routing fixes the wrong-workspace bug
+
+**Goal:** prove the header overrides what the client reports.
+
+1. In the app, **Workspaces → New mapping**: map `D:\proj\alpha` to a Space +
+   a distinctive FeatureSet (call it _Alpha FS_, with a tool only it has).
+   Map `D:\proj\beta` to a different _Beta FS_.
+2. In the `D:\proj\alpha` mapping, open **Connect apps to this folder**, tick
+   **Cursor**, and click **Install into 1 app**. Confirm
+   `D:\proj\alpha\.cursor\mcp.json` now contains an `mcpmux` entry with
+   `"headers": { "X-Mcpmux-Workspace": "D:\\proj\\alpha" }`.
+3. Repeat for `D:\proj\beta`.
+4. Open **both** folders in Cursor (two windows). In each, ask the agent to
+   list mcpmux tools (or invoke `@mux`).
+
+**Expected:** the `alpha` window sees _Alpha FS_ tools; the `beta` window sees
+_Beta FS_ tools. Before this change, both windows showed whichever folder
+Cursor happened to report — the bug.
+
+**Verify in logs** (`%LOCALAPPDATA%\com.mcpmux.desktop\logs\mcpmux.<date>.log`):
+
+- `[SessionRoots] pinned explicit workspace root from X-Mcpmux-Workspace header`
+  with the right path per session.
+- `[FeatureSetResolver] resolved via WorkspaceBinding workspace_root=d:\proj\alpha`
+  (and `…\beta`) — note the header path wins even if Cursor also reports a
+  different root.
+
+---
+
+## B. One-click install — create and extend
+
+1. **New folder, no config:** pick a fresh folder with no `.cursor/` etc.
+   Install for Cursor + Claude Code + VS Code. Confirm three files are
+   **created**: `.cursor/mcp.json`, `.mcp.json`, `.vscode/mcp.json`, each with
+   the correct top-level key (`mcpServers` / `mcpServers` / `servers`) and the
+   workspace header.
+2. **Existing config, preserved:** in a folder that already has a
+   `.cursor/mcp.json` with another server, install again. Confirm:
+   - the other server is still present,
+   - an `mcpmux` entry was added/updated,
+   - a `mcp.json.mcpmux-bak` backup was written.
+3. **Non-JSON guard:** put a `//` comment in `.cursor/mcp.json`, install, and
+   confirm that client reports an **error** ("not plain JSON…") and the file is
+   left untouched (no clobber).
+4. **Copy config:** click the copy icon on a client row, paste — you get a full
+   `{ "<key>": { "mcpmux": { … } } }` snippet for that client.
+
+---
+
+## C. Disable authentication
+
+1. **Settings → Security → Disable authentication: ON.** Toast confirms.
+2. Connect a client whose config has **no** `Authorization` header (the
+   installer writes none) — e.g. the Cursor config from step A.
+
+**Expected:** the client connects and resolves normally (no 401). Logs show
+`→ MCP` lines with `client=mcpmux-anon…` for tokenless requests.
+
+3. **Toggle OFF again.** A tokenless client now gets `401`; a client with a
+   valid access key still connects (lenient — a valid token is always honored).
+4. Restart the app with the toggle ON and confirm it persists (seeded into the
+   gateway at startup).
+
+The install panel's inline **Disable authentication** button (shown when auth
+is on) performs the same toggle without leaving the flow.
+
+---
+
+## D. Self-introductory hints (discoverability)
+
+- **Approval sheet** (open an unmapped folder in a connected app): shows the
+  "Connect apps to this folder" tip.
+- **Apps page → a client → "Routing is workspace-driven":** mentions installing
+  a per-workspace config when a client doesn't report folders reliably.
+- **Install panel:** shows the auth state and offers to disable it inline.
+
+---
+
+## Automated tests (run before manual)
+
+```bash
+pnpm test:rust:int    # resolver: pinned-header routing, override, fallback
+pnpm test:rust:unit   # session_roots pin/shadow/clear; GatewayState auth toggle;
+                      # workspace_install merge/create/extend/backup
+pnpm test:ts -- WorkspaceInstallPanel
+```
+
+All should pass.

--- a/tests/rust/tests/integration/feature_set_resolver.rs
+++ b/tests/rust/tests/integration/feature_set_resolver.rs
@@ -655,3 +655,85 @@ async fn two_sessions_on_same_root_resolve_to_the_same_binding() {
     assert_eq!(r2.feature_set_ids, vec![f.fs_a_id.clone()]);
     assert_eq!(r1.space_id, r2.space_id);
 }
+
+// ---------------------------------------------------------------------------
+// Explicit workspace root via the X-Mcpmux-Workspace header (pinned root)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pinned_header_root_routes_to_binding_without_any_reported_roots() {
+    // The deterministic fix for clients that don't report MCP roots reliably
+    // (e.g. Cursor multiplexing one MCP host across windows): a session flagged
+    // explicitly rootless, with no reported roots, still routes to its
+    // workspace binding purely from the X-Mcpmux-Workspace header the gateway
+    // pinned.
+    let f = Fixture::new().await;
+    f.binding_repo
+        .create(&WorkspaceBinding::new(
+            normalize_workspace_root(test_root()),
+            f.space_id,
+            f.fs_a_id.clone(),
+        ))
+        .await
+        .unwrap();
+
+    f.session_roots.set_roots_capable("s", false); // client says it has no roots
+    f.session_roots.set_pinned("s", test_root()); // ...but the header pins one
+
+    let r = f.resolver.resolve(Some("s"), None).await.unwrap();
+    assert_eq!(r.source, ResolutionSource::WorkspaceBinding);
+    assert_eq!(r.space_id, Some(f.space_id));
+    assert_eq!(r.feature_set_ids, vec![f.fs_a_id]);
+}
+
+#[tokio::test]
+async fn pinned_header_root_overrides_a_conflicting_reported_root() {
+    // The header is authoritative. When the client reports a stale/wrong root
+    // AND a header root is pinned, the pinned one wins — exactly the Cursor
+    // "reported the wrong window's root" failure, now corrected.
+    let f = Fixture::new().await;
+    let (reported, pinned) = if cfg!(windows) {
+        ("d:\\work\\reported", "d:\\work\\pinned")
+    } else {
+        ("/work/reported", "/work/pinned")
+    };
+    f.binding_repo
+        .create(&WorkspaceBinding::new(
+            normalize_workspace_root(reported),
+            f.space_id,
+            f.fs_a_id.clone(),
+        ))
+        .await
+        .unwrap();
+    f.binding_repo
+        .create(&WorkspaceBinding::new(
+            normalize_workspace_root(pinned),
+            f.space_id,
+            f.fs_b_id.clone(),
+        ))
+        .await
+        .unwrap();
+
+    f.session_roots.set("s", [reported]);
+    f.session_roots.set_roots_capable("s", true);
+    f.session_roots.set_pinned("s", pinned);
+
+    let r = f.resolver.resolve(Some("s"), None).await.unwrap();
+    assert_eq!(r.source, ResolutionSource::WorkspaceBinding);
+    // Resolved to the PINNED root's FS (B), not the reported root's FS (A).
+    assert_eq!(r.feature_set_ids, vec![f.fs_b_id]);
+    assert_ne!(r.feature_set_ids, vec![f.fs_a_id]);
+}
+
+#[tokio::test]
+async fn pinned_header_root_without_binding_falls_back_to_space_default() {
+    // A header root for an as-yet-unmapped folder still works out of the box on
+    // the Space default (upstream emits WorkspaceNeedsBinding so the user can
+    // attach an explicit mapping).
+    let f = Fixture::new().await;
+    f.session_roots.set_pinned("s", test_root());
+    let r = f.resolver.resolve(Some("s"), None).await.unwrap();
+    assert_eq!(r.source, ResolutionSource::SpaceDefault);
+    assert_eq!(r.feature_set_ids, vec![f.starter_fs_id.clone()]);
+    assert_eq!(r.space_id, Some(f.space_id));
+}

--- a/tests/rust/tests/integration/feature_set_resolver.rs
+++ b/tests/rust/tests/integration/feature_set_resolver.rs
@@ -726,6 +726,49 @@ async fn pinned_header_root_overrides_a_conflicting_reported_root() {
 }
 
 #[tokio::test]
+async fn header_takes_priority_but_reported_roots_still_map_without_one() {
+    // The two mechanisms coexist by design: a session that only reports MCP
+    // roots (no header) keeps mapping via those roots; pinning a header root
+    // then overrides them. This guards against the pin ever becoming
+    // unconditional and breaking roots-reporting clients (VS Code, Claude Code).
+    let f = Fixture::new().await;
+    let (root_a, root_b) = if cfg!(windows) {
+        ("d:\\work\\a", "d:\\work\\b")
+    } else {
+        ("/work/a", "/work/b")
+    };
+    f.binding_repo
+        .create(&WorkspaceBinding::new(
+            normalize_workspace_root(root_a),
+            f.space_id,
+            f.fs_a_id.clone(),
+        ))
+        .await
+        .unwrap();
+    f.binding_repo
+        .create(&WorkspaceBinding::new(
+            normalize_workspace_root(root_b),
+            f.space_id,
+            f.fs_b_id.clone(),
+        ))
+        .await
+        .unwrap();
+
+    // No header pinned → the reported root drives resolution (FS A).
+    f.session_roots.set("s", [root_a]);
+    f.session_roots.set_roots_capable("s", true);
+    let reported = f.resolver.resolve(Some("s"), None).await.unwrap();
+    assert_eq!(reported.source, ResolutionSource::WorkspaceBinding);
+    assert_eq!(reported.feature_set_ids, vec![f.fs_a_id.clone()]);
+
+    // Pin a header root for a different folder → it takes priority (FS B).
+    f.session_roots.set_pinned("s", root_b);
+    let pinned = f.resolver.resolve(Some("s"), None).await.unwrap();
+    assert_eq!(pinned.source, ResolutionSource::WorkspaceBinding);
+    assert_eq!(pinned.feature_set_ids, vec![f.fs_b_id.clone()]);
+}
+
+#[tokio::test]
 async fn pinned_header_root_without_binding_falls_back_to_space_default() {
     // A header root for an as-yet-unmapped folder still works out of the box on
     // the Space default (upstream emits WorkspaceNeedsBinding so the user can

--- a/tests/rust/tests/streamable_http/auth_disable.rs
+++ b/tests/rust/tests/streamable_http/auth_disable.rs
@@ -1,0 +1,180 @@
+//! End-to-end proof that the gateway is *truly* authless when the
+//! `gateway.auth_disabled` toggle is on.
+//!
+//! Unlike `gateway_notifications.rs` (which bypasses auth with a test
+//! middleware), this drives the **real** `mcp_oauth_middleware` over HTTP and
+//! sends requests with **no** `Authorization` header:
+//!   - auth disabled → the request is accepted and an anonymous client identity
+//!     is injected (200, not 401),
+//!   - auth required (default) → the same tokenless request is rejected (401).
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    middleware,
+    response::{IntoResponse, Response},
+    routing::post,
+    Router,
+};
+use mcpmux_core::{DomainEvent, ServerDiscoveryService, ServerLogManager};
+use mcpmux_gateway::{
+    mcp::mcp_oauth_middleware,
+    server::{DependenciesBuilder, GatewayDependencies, GatewayState, ServiceContainer},
+};
+use mcpmux_storage::SqliteSpaceRepository;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use tests::db::TestDatabase;
+use tests::mocks::*;
+
+/// Minimal `/mcp` handler that echoes the gateway-injected client id so the
+/// test can confirm the middleware ran and assigned an identity.
+async fn echo_client_id(req: Request<Body>) -> Response {
+    let cid = req
+        .headers()
+        .get("x-mcpmux-client-id")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    (StatusCode::OK, cid).into_response()
+}
+
+struct Harness {
+    url: String,
+    ct: CancellationToken,
+}
+
+impl Harness {
+    /// Boot a gateway exposing `/mcp` behind the REAL oauth middleware, with the
+    /// inbound-auth toggle set to `auth_disabled`.
+    async fn start(auth_disabled: bool) -> Self {
+        let ct = CancellationToken::new();
+        let space_id = Uuid::new_v4();
+
+        let test_db = TestDatabase::in_memory();
+        let database = Arc::new(tokio::sync::Mutex::new(test_db.db));
+
+        let space_repo = Arc::new(SqliteSpaceRepository::new(database.clone()));
+        let space = mcpmux_core::domain::Space {
+            id: space_id,
+            name: "Test Space".to_string(),
+            icon: None,
+            description: None,
+            is_default: true,
+            sort_order: 0,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        mcpmux_core::SpaceRepository::create(&*space_repo, &space)
+            .await
+            .expect("create space");
+        mcpmux_core::SpaceRepository::set_default(&*space_repo, &space_id)
+            .await
+            .expect("set default");
+
+        let deps = DependenciesBuilder::new()
+            .with_installed_server_repo(Arc::new(MockInstalledServerRepository::new()))
+            .with_credential_repo(Arc::new(MockCredentialRepository::new()))
+            .with_backend_oauth_repo(Arc::new(MockOutboundOAuthRepository::new()))
+            .with_feature_repo(Arc::new(MockServerFeatureRepository::new())
+                as Arc<dyn mcpmux_core::ServerFeatureRepository>)
+            .with_feature_set_repo(Arc::new(MockFeatureSetRepository::new())
+                as Arc<dyn mcpmux_core::FeatureSetRepository>)
+            .with_server_discovery(Arc::new(ServerDiscoveryService::new(
+                std::path::PathBuf::from("test-data"),
+                std::path::PathBuf::from("test-spaces"),
+            )))
+            .with_log_manager(Arc::new(ServerLogManager::new(
+                mcpmux_core::LogConfig::default(),
+            )))
+            .with_database(database)
+            .build()
+            .expect("build dependencies");
+        let deps = GatewayDependencies {
+            space_repo: space_repo as Arc<dyn mcpmux_core::SpaceRepository>,
+            ..deps
+        };
+
+        let (event_tx, _) = broadcast::channel::<DomainEvent>(64);
+        let mut gw_state = GatewayState::new(event_tx.clone());
+        gw_state.set_base_url("http://127.0.0.1:0".to_string());
+        // No JWT secret needed: these tests send no token, so the auth-required
+        // path 401s before the secret is ever consulted.
+        gw_state.set_auth_disabled(auth_disabled);
+        let gateway_state = Arc::new(tokio::sync::RwLock::new(gw_state));
+
+        let services = Arc::new(ServiceContainer::initialize(
+            &deps,
+            event_tx.clone(),
+            gateway_state,
+        ));
+
+        let router = Router::new().route("/mcp", post(echo_client_id)).layer(
+            middleware::from_fn_with_state(services.clone(), mcp_oauth_middleware),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let port = listener.local_addr().unwrap().port();
+        let ct_clone = ct.clone();
+        tokio::spawn(async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move { ct_clone.cancelled().await })
+                .await
+                .unwrap();
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        Self {
+            url: format!("http://127.0.0.1:{port}/mcp"),
+            ct,
+        }
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        self.ct.cancel();
+    }
+}
+
+#[tokio::test]
+async fn authless_gateway_accepts_request_without_token() {
+    let h = Harness::start(true).await;
+    let resp = reqwest::Client::new()
+        .post(&h.url)
+        .header("content-type", "application/json")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#)
+        .send()
+        .await
+        .expect("request");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "auth-disabled gateway must accept a tokenless request"
+    );
+    // The middleware injected an anonymous identity rather than rejecting.
+    let body = resp.text().await.unwrap();
+    assert_eq!(body, "mcpmux-anonymous");
+}
+
+#[tokio::test]
+async fn auth_required_gateway_rejects_request_without_token() {
+    let h = Harness::start(false).await;
+    let resp = reqwest::Client::new()
+        .post(&h.url)
+        .header("content-type", "application/json")
+        .body(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#)
+        .send()
+        .await
+        .expect("request");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "default gateway must reject a tokenless request"
+    );
+}

--- a/tests/rust/tests/streamable_http/mod.rs
+++ b/tests/rust/tests/streamable_http/mod.rs
@@ -5,5 +5,6 @@
 //! - Server-initiated notifications (list_changed via SSE)
 //! - Proper protocol negotiation
 
+mod auth_disable;
 mod gateway_notifications;
 mod notifications;

--- a/tests/ts/components/HomePageStats.test.tsx
+++ b/tests/ts/components/HomePageStats.test.tsx
@@ -36,6 +36,7 @@ vi.mock('@/lib/api/registry', () => ({ listInstalledServers: mockListInstalled }
 vi.mock('@/stores', () => ({
   useViewSpace: () => ({ id: 'space-1', name: 'My Space' }),
   useNavigateTo: () => () => {},
+  useSetPendingWorkspaceNew: () => () => {},
 }));
 vi.mock('@/components/ConnectionCard', () => ({ ConnectionCard: () => null }));
 

--- a/tests/ts/components/WorkspaceInstallPanel.test.tsx
+++ b/tests/ts/components/WorkspaceInstallPanel.test.tsx
@@ -21,6 +21,7 @@ const {
   getAuthMock,
   gatewayStatusMock,
   navigateMock,
+  setSectionMock,
 } = vi.hoisted(() => ({
   listClientsMock: vi.fn(),
   installMock: vi.fn(),
@@ -28,6 +29,7 @@ const {
   getAuthMock: vi.fn(),
   gatewayStatusMock: vi.fn(),
   navigateMock: vi.fn(),
+  setSectionMock: vi.fn(),
 }));
 
 vi.mock('@/lib/api/workspaceInstall', () => ({
@@ -43,6 +45,7 @@ vi.mock('@/lib/api/gateway', () => ({
 
 vi.mock('@/stores', () => ({
   useNavigateTo: () => navigateMock,
+  useSetPendingSettingsSection: () => setSectionMock,
 }));
 
 import { WorkspaceInstallPanel } from '@/features/workspaces/WorkspaceInstallPanel';
@@ -65,6 +68,7 @@ describe('WorkspaceInstallPanel', () => {
     snippetMock.mockReset();
     getAuthMock.mockReset().mockResolvedValue(true);
     navigateMock.mockReset();
+    setSectionMock.mockReset();
     gatewayStatusMock
       .mockReset()
       .mockResolvedValue({ running: true, url: 'http://localhost:45818' });
@@ -134,6 +138,7 @@ describe('WorkspaceInstallPanel', () => {
     // flipping it inline.
     const openSettings = await screen.findByTestId('workspace-install-open-auth-settings');
     await user.click(openSettings);
+    expect(setSectionMock).toHaveBeenCalledWith('security');
     expect(navigateMock).toHaveBeenCalledWith('settings');
   });
 

--- a/tests/ts/components/WorkspaceInstallPanel.test.tsx
+++ b/tests/ts/components/WorkspaceInstallPanel.test.tsx
@@ -19,15 +19,15 @@ const {
   installMock,
   snippetMock,
   getAuthMock,
-  setAuthMock,
   gatewayStatusMock,
+  navigateMock,
 } = vi.hoisted(() => ({
   listClientsMock: vi.fn(),
   installMock: vi.fn(),
   snippetMock: vi.fn(),
   getAuthMock: vi.fn(),
-  setAuthMock: vi.fn(),
   gatewayStatusMock: vi.fn(),
+  navigateMock: vi.fn(),
 }));
 
 vi.mock('@/lib/api/workspaceInstall', () => ({
@@ -35,11 +35,14 @@ vi.mock('@/lib/api/workspaceInstall', () => ({
   installWorkspaceMcpConfig: installMock,
   generateWorkspaceConfigSnippet: snippetMock,
   getGatewayAuthDisabled: getAuthMock,
-  setGatewayAuthDisabled: setAuthMock,
 }));
 
 vi.mock('@/lib/api/gateway', () => ({
   getGatewayStatus: gatewayStatusMock,
+}));
+
+vi.mock('@/stores', () => ({
+  useNavigateTo: () => navigateMock,
 }));
 
 import { WorkspaceInstallPanel } from '@/features/workspaces/WorkspaceInstallPanel';
@@ -61,7 +64,7 @@ describe('WorkspaceInstallPanel', () => {
     installMock.mockReset();
     snippetMock.mockReset();
     getAuthMock.mockReset().mockResolvedValue(true);
-    setAuthMock.mockReset();
+    navigateMock.mockReset();
     gatewayStatusMock
       .mockReset()
       .mockResolvedValue({ running: true, url: 'http://localhost:45818' });
@@ -122,20 +125,16 @@ describe('WorkspaceInstallPanel', () => {
     expect(installMock.mock.calls[0][0].clients).toEqual(['opencode']);
   });
 
-  it('shows the auth nudge and disables auth inline', async () => {
+  it('shows the auth nudge and routes to Settings (no inline disable)', async () => {
     const user = userEvent.setup();
     getAuthMock.mockResolvedValue(false); // auth currently required
-    setAuthMock.mockResolvedValue(true);
     render(<WorkspaceInstallPanel workspaceRoot={ROOT} />);
 
-    const disableBtn = await screen.findByTestId('workspace-install-disable-auth');
-    await user.click(disableBtn);
-
-    await waitFor(() => expect(setAuthMock).toHaveBeenCalledWith(true));
-    // Nudge is replaced by the "auth is off" confirmation.
-    await waitFor(() =>
-      expect(screen.queryByTestId('workspace-install-auth-nudge')).toBeNull()
-    );
+    // Auth is application-wide: the panel links to Settings instead of
+    // flipping it inline.
+    const openSettings = await screen.findByTestId('workspace-install-open-auth-settings');
+    await user.click(openSettings);
+    expect(navigateMock).toHaveBeenCalledWith('settings');
   });
 
   it('copies a client snippet to the clipboard', async () => {

--- a/tests/ts/components/WorkspaceInstallPanel.test.tsx
+++ b/tests/ts/components/WorkspaceInstallPanel.test.tsx
@@ -56,6 +56,7 @@ const ROOT = process.platform === 'win32' ? 'd:\\proj\\app' : '/proj/app';
 
 describe('WorkspaceInstallPanel', () => {
   beforeEach(() => {
+    localStorage.clear();
     listClientsMock.mockReset().mockResolvedValue(CLIENTS);
     installMock.mockReset();
     snippetMock.mockReset();
@@ -92,6 +93,33 @@ describe('WorkspaceInstallPanel', () => {
     expect(arg.clients).toEqual(['cursor', 'claude-code', 'vscode']);
     // Result row is shown.
     expect(await screen.findByTestId('workspace-install-results')).toBeTruthy();
+  });
+
+  it('remembers the previous client selection across renders', async () => {
+    const user = userEvent.setup();
+    installMock.mockResolvedValue([]);
+
+    // First mount: deselect the defaults down to just opencode, then install
+    // (which persists the selection).
+    const first = render(<WorkspaceInstallPanel workspaceRoot={ROOT} />);
+    await screen.findByTestId('workspace-install-client-cursor');
+    for (const id of ['cursor', 'claude-code', 'vscode']) {
+      await user.click(screen.getByTestId(`workspace-install-client-${id}`));
+    }
+    await user.click(screen.getByTestId('workspace-install-client-opencode'));
+    await user.click(screen.getByTestId('workspace-install-button'));
+    await waitFor(() => expect(installMock).toHaveBeenCalled());
+    expect(installMock.mock.calls[0][0].clients).toEqual(['opencode']);
+    first.unmount();
+
+    // Second mount: the remembered selection (opencode only) is restored, not
+    // the big-three default.
+    installMock.mockClear();
+    render(<WorkspaceInstallPanel workspaceRoot={ROOT} />);
+    await screen.findByTestId('workspace-install-button');
+    await user.click(screen.getByTestId('workspace-install-button'));
+    await waitFor(() => expect(installMock).toHaveBeenCalled());
+    expect(installMock.mock.calls[0][0].clients).toEqual(['opencode']);
   });
 
   it('shows the auth nudge and disables auth inline', async () => {

--- a/tests/ts/components/WorkspaceInstallPanel.test.tsx
+++ b/tests/ts/components/WorkspaceInstallPanel.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Workspaces — "Connect apps to this folder" install panel.
+ *
+ * The panel must: list the supported clients, write the selected clients'
+ * configs via `install_workspace_mcp_config` with this folder's path as the
+ * `X-Mcpmux-Workspace` header (carried server-side), copy a per-client snippet,
+ * and surface (and be able to flip) the system-wide auth toggle inline.
+ *
+ * `@mcpmux/ui` is aliased to real source in vitest.config, so the real Button
+ * renders.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const {
+  listClientsMock,
+  installMock,
+  snippetMock,
+  getAuthMock,
+  setAuthMock,
+  gatewayStatusMock,
+} = vi.hoisted(() => ({
+  listClientsMock: vi.fn(),
+  installMock: vi.fn(),
+  snippetMock: vi.fn(),
+  getAuthMock: vi.fn(),
+  setAuthMock: vi.fn(),
+  gatewayStatusMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api/workspaceInstall', () => ({
+  listWorkspaceInstallClients: listClientsMock,
+  installWorkspaceMcpConfig: installMock,
+  generateWorkspaceConfigSnippet: snippetMock,
+  getGatewayAuthDisabled: getAuthMock,
+  setGatewayAuthDisabled: setAuthMock,
+}));
+
+vi.mock('@/lib/api/gateway', () => ({
+  getGatewayStatus: gatewayStatusMock,
+}));
+
+import { WorkspaceInstallPanel } from '@/features/workspaces/WorkspaceInstallPanel';
+
+const CLIENTS = [
+  { id: 'cursor', label: 'Cursor', config_path: '.cursor/mcp.json' },
+  { id: 'claude-code', label: 'Claude Code', config_path: '.mcp.json' },
+  { id: 'vscode', label: 'VS Code / Copilot', config_path: '.vscode/mcp.json' },
+  { id: 'opencode', label: 'opencode', config_path: 'opencode.json' },
+  { id: 'zed', label: 'Zed', config_path: '.zed/settings.json' },
+];
+
+const ROOT = process.platform === 'win32' ? 'd:\\proj\\app' : '/proj/app';
+
+describe('WorkspaceInstallPanel', () => {
+  beforeEach(() => {
+    listClientsMock.mockReset().mockResolvedValue(CLIENTS);
+    installMock.mockReset();
+    snippetMock.mockReset();
+    getAuthMock.mockReset().mockResolvedValue(true);
+    setAuthMock.mockReset();
+    gatewayStatusMock
+      .mockReset()
+      .mockResolvedValue({ running: true, url: 'http://localhost:45818' });
+  });
+
+  it('lists every supported client', async () => {
+    render(<WorkspaceInstallPanel workspaceRoot={ROOT} />);
+    expect(await screen.findByText('Cursor')).toBeTruthy();
+    for (const c of CLIENTS) {
+      expect(screen.getByTestId(`workspace-install-client-${c.id}`)).toBeTruthy();
+    }
+  });
+
+  it('installs the default-selected clients with the gateway /mcp url', async () => {
+    const user = userEvent.setup();
+    installMock.mockResolvedValue([
+      { client: 'cursor', label: 'Cursor', path: '/p/.cursor/mcp.json', action: 'created', backed_up: null, error: null },
+    ]);
+    render(<WorkspaceInstallPanel workspaceRoot={ROOT} />);
+
+    const btn = await screen.findByTestId('workspace-install-button');
+    await user.click(btn);
+
+    await waitFor(() => expect(installMock).toHaveBeenCalledTimes(1));
+    const arg = installMock.mock.calls[0][0];
+    expect(arg.workspaceRoot).toBe(ROOT);
+    expect(arg.serverUrl).toBe('http://localhost:45818/mcp');
+    // Defaults to the common three.
+    expect(arg.clients).toEqual(['cursor', 'claude-code', 'vscode']);
+    // Result row is shown.
+    expect(await screen.findByTestId('workspace-install-results')).toBeTruthy();
+  });
+
+  it('shows the auth nudge and disables auth inline', async () => {
+    const user = userEvent.setup();
+    getAuthMock.mockResolvedValue(false); // auth currently required
+    setAuthMock.mockResolvedValue(true);
+    render(<WorkspaceInstallPanel workspaceRoot={ROOT} />);
+
+    const disableBtn = await screen.findByTestId('workspace-install-disable-auth');
+    await user.click(disableBtn);
+
+    await waitFor(() => expect(setAuthMock).toHaveBeenCalledWith(true));
+    // Nudge is replaced by the "auth is off" confirmation.
+    await waitFor(() =>
+      expect(screen.queryByTestId('workspace-install-auth-nudge')).toBeNull()
+    );
+  });
+
+  it('copies a client snippet to the clipboard', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    snippetMock.mockResolvedValue({
+      client: 'cursor',
+      label: 'Cursor',
+      config_path: '.cursor/mcp.json',
+      content: '{ "mcpServers": { "mcpmux": {} } }',
+    });
+    render(<WorkspaceInstallPanel workspaceRoot={ROOT} />);
+
+    const copyBtn = await screen.findByTestId('workspace-install-copy-cursor');
+    await user.click(copyBtn);
+
+    await waitFor(() =>
+      expect(snippetMock).toHaveBeenCalledWith(
+        expect.objectContaining({ client: 'cursor', workspaceRoot: ROOT })
+      )
+    );
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+  });
+
+  it('blocks install until the gateway is running', async () => {
+    gatewayStatusMock.mockResolvedValue({ running: false, url: null });
+    render(<WorkspaceInstallPanel workspaceRoot={ROOT} />);
+    const btn = await screen.findByTestId('workspace-install-button');
+    await waitFor(() => expect(btn).toHaveProperty('disabled', true));
+    expect(btn.textContent).toContain('Start the gateway');
+  });
+});

--- a/tests/ts/components/WorkspaceSetupWizard.test.tsx
+++ b/tests/ts/components/WorkspaceSetupWizard.test.tsx
@@ -82,7 +82,9 @@ describe('WorkspaceSetupWizard', () => {
       space_id: 's1',
       feature_set_ids: ['fs_starter'],
     });
-    await waitFor(() => expect(p.onClose).toHaveBeenCalled());
+    // The parent navigates to the new mapping's inspector (effective features);
+    // the wizard itself does not close.
+    expect(p.onClose).not.toHaveBeenCalled();
   });
 
   it('lets you go Back from a later step', async () => {

--- a/tests/ts/components/WorkspaceSetupWizard.test.tsx
+++ b/tests/ts/components/WorkspaceSetupWizard.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Workspaces — "Set up a folder" walkthrough.
+ *
+ * Verifies the 3-step create flow: pick a folder (step 1, required), advance
+ * through the optional connect-apps step (2), and on the tools step (3) Finish
+ * creates a binding with the folder path, chosen Space, and the default Starter
+ * feature set pre-selected.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const { openMock, validateMock } = vi.hoisted(() => ({
+  openMock: vi.fn(),
+  validateMock: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: openMock }));
+vi.mock('@/lib/api/workspaceBindings', () => ({ validateWorkspaceRoot: validateMock }));
+vi.mock('@/lib/api/featureSets', () => ({
+  isStarterFeatureSet: (fs: { feature_set_type: string }) =>
+    fs.feature_set_type === 'starter' || fs.feature_set_type === 'default',
+}));
+// Step 2 embeds the install panel; stub it out — it has its own tests.
+vi.mock('@/features/workspaces/WorkspaceInstallPanel', () => ({
+  WorkspaceInstallPanel: () => null,
+}));
+
+import { WorkspaceSetupWizard } from '@/features/workspaces/WorkspaceSetupWizard';
+
+const SPACES = [
+  { id: 's1', name: 'Default', icon: '', description: null, is_default: true, sort_order: 0, created_at: '', updated_at: '' },
+];
+const FEATURE_SETS = [
+  { id: 'fs_starter', name: 'Starter', space_id: 's1', feature_set_type: 'starter' },
+  { id: 'fs_a', name: 'Custom A', space_id: 's1', feature_set_type: 'custom' },
+];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const props = (over: any = {}) => ({
+  spaces: SPACES as any,
+  featureSets: FEATURE_SETS as any,
+  reportedRoots: ['/proj/app'],
+  existingBindings: [],
+  onClose: vi.fn(),
+  onCreate: vi.fn().mockResolvedValue({ id: 'b1' }),
+  onError: vi.fn(),
+  ...over,
+});
+
+describe('WorkspaceSetupWizard', () => {
+  beforeEach(() => {
+    openMock.mockReset();
+    validateMock.mockReset();
+  });
+
+  it('walks folder → apps → tools and Finish creates the binding', async () => {
+    const user = userEvent.setup();
+    const p = props();
+    render(<WorkspaceSetupWizard {...p} />);
+
+    // Step 1: Next is disabled until a folder is chosen.
+    expect(screen.getByTestId('wizard-step-folder')).toBeTruthy();
+    expect(screen.getByTestId('wizard-next')).toHaveProperty('disabled', true);
+
+    // Quick-pick the detected folder.
+    await user.click(screen.getByRole('button', { name: /proj\/app/ }));
+    expect(screen.getByTestId('wizard-next')).toHaveProperty('disabled', false);
+    await user.click(screen.getByTestId('wizard-next'));
+
+    // Step 2: connect apps (stubbed) → Next.
+    expect(screen.getByTestId('wizard-step-apps')).toBeTruthy();
+    await user.click(screen.getByTestId('wizard-next'));
+
+    // Step 3: Starter is pre-selected; Finish creates the binding.
+    expect(screen.getByTestId('wizard-step-tools')).toBeTruthy();
+    await user.click(screen.getByTestId('wizard-finish'));
+
+    await waitFor(() => expect(p.onCreate).toHaveBeenCalledTimes(1));
+    expect(p.onCreate).toHaveBeenCalledWith({
+      workspace_root: '/proj/app',
+      space_id: 's1',
+      feature_set_ids: ['fs_starter'],
+    });
+    await waitFor(() => expect(p.onClose).toHaveBeenCalled());
+  });
+
+  it('lets you go Back from a later step', async () => {
+    const user = userEvent.setup();
+    render(<WorkspaceSetupWizard {...props()} />);
+    await user.click(screen.getByRole('button', { name: /proj\/app/ }));
+    await user.click(screen.getByTestId('wizard-next')); // → step 2
+    expect(screen.getByTestId('wizard-step-apps')).toBeTruthy();
+    await user.click(screen.getByTestId('wizard-back')); // → step 1
+    expect(screen.getByTestId('wizard-step-folder')).toBeTruthy();
+  });
+});

--- a/tests/ts/components/WorkspacesClearUnmapped.test.tsx
+++ b/tests/ts/components/WorkspacesClearUnmapped.test.tsx
@@ -43,6 +43,8 @@ vi.mock('@/lib/api/featureSets', () => ({
 
 vi.mock('@/stores', () => ({
   useSpaces: () => [],
+  usePendingWorkspaceNew: () => false,
+  useSetPendingWorkspaceNew: () => () => {},
 }));
 
 import { WorkspacesPage } from '@/features/workspaces/WorkspacesPage';

--- a/tests/ts/components/WorkspacesMappedFilter.test.tsx
+++ b/tests/ts/components/WorkspacesMappedFilter.test.tsx
@@ -41,6 +41,8 @@ vi.mock('@/lib/api/featureSets', () => ({
 
 vi.mock('@/stores', () => ({
   useSpaces: () => [{ id: 's1', name: 'Space One' }],
+  usePendingWorkspaceNew: () => false,
+  useSetPendingWorkspaceNew: () => () => {},
 }));
 
 import { WorkspacesPage } from '@/features/workspaces/WorkspacesPage';


### PR DESCRIPTION
## Why

Clients that don't report MCP `roots` reliably — notably **Cursor**, which multiplexes one MCP host across windows with `roots.listChanged=false` — could not be routed to the right workspace binding, so `@mux` returned another window's FeatureSet. `roots` is also deprecated (SEP-2577) and sessions are being removed (SEP-2575/2567), so **connection-carried identity**, not the client's reported roots, is the durable signal.

## What

**Gateway**
- **`X-Mcpmux-Workspace` header routing.** The header value is the workspace folder path; the OAuth middleware pins it into `SessionRootsRegistry`, where it *shadows* the client's probed roots in `get()`. The resolver, probe-skip, and prompt-root all read through `get()`, so the header flows through Tier 1 unchanged — authoritative over a stale/absent reported root. Coexists with roots-based mapping (header wins); no new tier, param, or DB migration.
- **Optional system-wide disable of inbound auth** (`gateway.auth_disabled`, default off). Middleware is now lenient: a valid token is always honored, but with auth off a tokenless client is accepted as an anonymous identity on the default Space. Seeded at startup, flipped live.

**Desktop**
- **Per-workspace installer**: writes/extends project-local MCP configs (Cursor, Claude Code, VS Code/Copilot, opencode, Zed) with the workspace header — merge-not-clobber, backups, refuses non-JSON. Copy-snippet per client; remembers the last client selection.
- **Guided "Set up a folder" walkthrough** (create path; editing keeps the inspector): Folder → Connect apps → Tools (defaults to Starter, one-click Finish). After Finish it lands on the new mapping's inspector showing its **effective features**. A home **"Set up a folder"** CTA opens it.
- **Settings → Security** toggle for disabling auth; the install panel routes there (deep-links + flashes the section) rather than flipping it inline.

## Testing

- Rust: resolver header-priority + coexistence cases; registry pin/shadow/clear; `GatewayState` toggle; config-writer merge/create/extend/backup/reject-JSONC; **authless HTTP integration test** driving the real middleware (tokenless `/mcp` → 200 + anonymous when disabled, 401 when required).
- TS: install panel (install/copy/auth-route-to-settings/remembered selection/gateway-gating) and the setup walkthrough (3 steps, Finish creates binding, Back).
- Full suites green locally: **631 Rust, 220 TS.**
- Manual guide: `docs/manual/workspace-header-routing.md`.

## Notes
- `roots`-reporting clients (VS Code/Claude Code) are unaffected — the pin only applies when the header is present.
- Claude Desktop (stdio, no static headers) and global-only clients (Windsurf/Cline) are intentionally excluded from the per-workspace installer.

https://claude.ai/code/session_01Baan9JmzR43uxxRUh7CAMF