### PR TITLE
fix(ui): show official opencode logo in the Apps tab

### DIFF
--- a/apps/desktop/src/features/clients/ClientsPage.tsx
+++ b/apps/desktop/src/features/clients/ClientsPage.tsx
@@ -6,6 +6,9 @@ import claudeIcon from '@/assets/client-icons/claude.svg';
 import windsurfIcon from '@/assets/client-icons/windsurf.svg';
 import jetbrainsIcon from '@/assets/client-icons/jetbrains.svg';
 import androidStudioIcon from '@/assets/client-icons/android-studio.svg';
+import opencodeIcon from '@/assets/client-icons/opencode.svg';
+import opencodeIconDark from '@/assets/client-icons/opencode-dark.svg';
+import { ClientBrandIcon } from '@/components/ClientBrandIcon';
 import { resolveKnownClientKey } from '@/lib/clientIcons';
 import {
   Laptop,
@@ -65,6 +68,18 @@ const CLIENT_ICON_ASSETS: Record<string, string> = {
 
 function ClientIcon({ logo_uri, client_name }: { logo_uri?: string | null; client_name: string }) {
   const knownKey = resolveKnownClientKey(client_name);
+  // opencode ships theme-specific marks; render our bundled official logo
+  // (overriding any outdated self-reported logo_uri).
+  if (knownKey === 'opencode') {
+    return (
+      <ClientBrandIcon
+        light={opencodeIcon}
+        dark={opencodeIconDark}
+        alt={client_name}
+        className="h-full w-full rounded object-contain"
+      />
+    );
+  }
   const iconUrl = (knownKey && CLIENT_ICON_ASSETS[knownKey]) || logo_uri;
   if (iconUrl) {
     return (

--- a/apps/desktop/src/lib/clientIcons.ts
+++ b/apps/desktop/src/lib/clientIcons.ts
@@ -21,6 +21,7 @@ const KNOWN_CLIENT_PATTERNS: { pattern: string; iconKey: string }[] = [
   { pattern: 'clion', iconKey: 'jetbrains' },
   { pattern: 'jetbrains', iconKey: 'jetbrains' },
   { pattern: 'cursor', iconKey: 'cursor' },
+  { pattern: 'opencode', iconKey: 'opencode' },
   { pattern: 'vscode', iconKey: 'vscode' },
   { pattern: 'claude', iconKey: 'claude' },
 ];

--- a/tests/ts/lib/clientIcons.test.ts
+++ b/tests/ts/lib/clientIcons.test.ts
@@ -38,6 +38,14 @@ describe('resolveKnownClientKey', () => {
     it('should resolve "codeium" to windsurf', () => {
       expect(resolveKnownClientKey('codeium')).toBe('windsurf');
     });
+
+    it('should resolve "opencode" to opencode', () => {
+      expect(resolveKnownClientKey('opencode')).toBe('opencode');
+    });
+
+    it('should resolve "opencode (mcpmux)" to opencode', () => {
+      expect(resolveKnownClientKey('opencode (mcpmux)')).toBe('opencode');
+    });
   });
 
   describe('prefix matches with parenthesised suffix', () => {


### PR DESCRIPTION
Follow-up to #184.

## Problem
A connected **opencode** client showed an outdated logo in the **Apps** (Clients) tab. `resolveKnownClientKey` didn't recognize "opencode", so the client card fell back to the client's self-reported `logo_uri` (a stale mark) instead of our bundled official logo.

## Fix
- Recognize `opencode` (and `opencode (…)`) in `resolveKnownClientKey`.
- Render the official, theme-aware opencode logo via `ClientBrandIcon`, overriding any self-reported `logo_uri`.

The official opencode assets + `ClientBrandIcon` landed in #184 (now on main), so this is a small, self-contained follow-up.

## Tests
- `resolveKnownClientKey` maps `opencode` / `opencode (mcpmux)` → `opencode`.
- Full TS suite green locally (224).
