### PR TITLE
chore: sync Cargo.lock workspace package versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2629,7 +2629,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcpmux"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-gateway"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-mcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "mcpmux-storage"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Summary

Syncs the workspace package versions recorded in `Cargo.lock` from `0.4.0` to `0.5.0`, matching the current workspace release version.

This avoids Cargo rewriting the lockfile during normal `cargo check`/test runs after the `0.5.0` release bump.

## Testing

- `cargo check --workspace --locked`
