### PR TITLE
feat: support configurable public gateway base URL

### DIFF
--- a/apps/desktop/src-tauri/src/commands/gateway.rs
+++ b/apps/desktop/src-tauri/src/commands/gateway.rs
@@ -1925,3 +1925,50 @@ pub struct PoolStatsResponse {
     pub connected_instances: usize,
     pub total_space_server_mappings: usize,
 }
+
+#[cfg(test)]
+mod public_base_url_tests {
+    use super::{advertised_base_url, normalize_public_base_url};
+
+    #[test]
+    fn normalize_accepts_https_origin_and_trims_trailing_slash() {
+        assert_eq!(
+            normalize_public_base_url("https://mcp.example.com/").unwrap(),
+            Some("https://mcp.example.com".to_string())
+        );
+        assert_eq!(
+            normalize_public_base_url("https://mcp.example.com:8443").unwrap(),
+            Some("https://mcp.example.com:8443".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_treats_blank_as_none() {
+        assert_eq!(normalize_public_base_url("").unwrap(), None);
+        assert_eq!(normalize_public_base_url("   ").unwrap(), None);
+    }
+
+    #[test]
+    fn normalize_rejects_unsafe_or_non_origin_urls() {
+        // Non-https, credentials, query/fragment, non-root path, and garbage all rejected.
+        assert!(normalize_public_base_url("http://mcp.example.com").is_err());
+        assert!(normalize_public_base_url("https://user:pass@mcp.example.com").is_err());
+        assert!(normalize_public_base_url("https://mcp.example.com/?x=1").is_err());
+        assert!(normalize_public_base_url("https://mcp.example.com/#frag").is_err());
+        assert!(normalize_public_base_url("https://mcp.example.com/mcp").is_err());
+        assert!(normalize_public_base_url("not a url").is_err());
+    }
+
+    #[test]
+    fn advertised_base_url_falls_back_to_localhost() {
+        assert_eq!(advertised_base_url(None, 45818), "http://localhost:45818");
+        assert_eq!(
+            advertised_base_url(Some("   "), 45818),
+            "http://localhost:45818"
+        );
+        assert_eq!(
+            advertised_base_url(Some("https://mcp.example.com/"), 45818),
+            "https://mcp.example.com"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/gateway.rs
+++ b/apps/desktop/src-tauri/src/commands/gateway.rs
@@ -53,8 +53,11 @@ pub struct PendingPortConflict {
 pub struct GatewayAppState {
     /// Gateway running flag
     pub running: bool,
-    /// Gateway URL
+    /// Gateway URL advertised to clients.
     pub url: Option<String>,
+    /// Locally bound port. This remains the actual listener port even when
+    /// `url` is a public tunnel origin such as https://mcp.example.com.
+    pub bound_port: Option<u16>,
     /// Gateway task + graceful-shutdown signal. `shutdown()` + awaiting
     /// `task` (with a timeout) lets the OS reclaim the listener socket
     /// cleanly; `.abort()` alone can leave an orphaned kernel-level bind.
@@ -121,6 +124,79 @@ pub(crate) async fn shutdown_gateway_handle(mut handle: mcpmux_gateway::GatewayS
 /// a fresh client connection automatically draws the user's eye to the
 /// mcpmux app instead of the dialog rendering invisibly under another
 /// window.
+const GATEWAY_PUBLIC_BASE_URL_KEY: &str = "gateway.public_base_url";
+
+pub(crate) fn normalize_public_base_url(raw: &str) -> Result<Option<String>, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let parsed = url::Url::parse(trimmed).map_err(|e| format!("Invalid public base URL: {}", e))?;
+
+    if parsed.scheme() != "https" {
+        return Err("Public base URL must start with https://".to_string());
+    }
+    if parsed.host_str().is_none() {
+        return Err("Public base URL must include a host".to_string());
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("Public base URL must not include credentials".to_string());
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        return Err("Public base URL must not include a query string or fragment".to_string());
+    }
+    if parsed.path() != "/" && !parsed.path().is_empty() {
+        return Err(
+            "Public base URL must be an origin only, for example https://mcp.example.com"
+                .to_string(),
+        );
+    }
+
+    let origin = match parsed.port() {
+        Some(port) => format!(
+            "{}://{}:{}",
+            parsed.scheme(),
+            parsed.host_str().unwrap(),
+            port
+        ),
+        None => format!("{}://{}", parsed.scheme(), parsed.host_str().unwrap()),
+    };
+    Ok(Some(origin.trim_end_matches('/').to_string()))
+}
+
+pub(crate) async fn load_public_base_url_from_repo(
+    settings_repository: &Arc<dyn mcpmux_core::AppSettingsRepository>,
+) -> Option<String> {
+    settings_repository
+        .get(GATEWAY_PUBLIC_BASE_URL_KEY)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|value| match normalize_public_base_url(&value) {
+            Ok(normalized) => normalized,
+            Err(e) => {
+                warn!(
+                    "[Gateway] Ignoring invalid persisted public base URL: {}",
+                    e
+                );
+                None
+            }
+        })
+}
+
+pub(crate) async fn load_public_base_url(app_state: &AppState) -> Option<String> {
+    load_public_base_url_from_repo(&app_state.settings_repository).await
+}
+
+pub(crate) fn advertised_base_url(public_base_url: Option<&str>, port: u16) -> String {
+    public_base_url
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(|url| url.trim_end_matches('/').to_string())
+        .unwrap_or_else(|| format!("http://localhost:{}", port))
+}
+
 pub(crate) fn focus_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
     use tauri::Manager;
     let Some(window) = app.get_webview_window("main") else {
@@ -896,9 +972,11 @@ pub async fn start_gateway(
         ));
     };
 
-    let url = format!("http://localhost:{}", final_port);
+    let public_base_url = load_public_base_url(&app_state).await;
+    let url = advertised_base_url(public_base_url.as_deref(), final_port);
+    let local_url = format!("http://localhost:{}", final_port);
 
-    info!("Starting gateway on {}", url);
+    info!("Starting gateway on {} (advertising {})", local_url, url);
 
     // Create dependencies using DI builder pattern
     let dependencies = create_gateway_dependencies(&app_state, app_handle.clone())?;
@@ -907,6 +985,7 @@ pub async fn start_gateway(
     let config = mcpmux_gateway::GatewayConfig {
         host: "127.0.0.1".to_string(), // Bind address must be IP
         port: final_port,
+        public_base_url: public_base_url.clone(),
         enable_cors: true,
     };
 
@@ -978,6 +1057,7 @@ pub async fn start_gateway(
     );
     state.running = true;
     state.url = Some(url.clone());
+    state.bound_port = Some(final_port);
     state.handle = Some(handle);
     state.gateway_state = Some(gw_state);
     state.pool_service = Some(pool_service);
@@ -1028,6 +1108,7 @@ pub async fn stop_gateway(
         let handle = state.handle.take();
         state.running = false;
         state.url = None;
+        state.bound_port = None;
         handle
     };
 
@@ -1075,7 +1156,9 @@ pub async fn get_gateway_port_settings(
 
     let active_port = {
         let state = gateway_state.read().await;
-        state.url.as_deref().and_then(parse_port_from_url)
+        state
+            .bound_port
+            .or_else(|| state.url.as_deref().and_then(parse_port_from_url))
     };
 
     Ok(GatewayPortSettings {
@@ -1164,6 +1247,94 @@ pub async fn set_gateway_auth_disabled(
     }
     info!("[Gateway] Inbound auth disabled set to {}", disabled);
     Ok(disabled)
+}
+
+/// Public URL configuration response.
+///
+/// `configured_public_base_url` is the persisted external origin advertised in
+/// OAuth metadata. `active_public_base_url` is the URL currently advertised by
+/// the running gateway, and `local_base_url` is the localhost listener.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GatewayPublicUrlSettings {
+    pub configured_public_base_url: Option<String>,
+    pub active_public_base_url: Option<String>,
+    pub local_base_url: Option<String>,
+}
+
+#[tauri::command]
+pub async fn get_gateway_public_url_settings(
+    gateway_state: State<'_, Arc<RwLock<GatewayAppState>>>,
+    app_state: State<'_, AppState>,
+) -> Result<GatewayPublicUrlSettings, String> {
+    let configured_public_base_url = load_public_base_url(&app_state).await;
+    let (active_public_base_url, local_base_url) = {
+        let state = gateway_state.read().await;
+        (
+            if state.running {
+                state.url.clone()
+            } else {
+                None
+            },
+            state
+                .bound_port
+                .map(|port| format!("http://localhost:{}", port)),
+        )
+    };
+
+    Ok(GatewayPublicUrlSettings {
+        configured_public_base_url,
+        active_public_base_url,
+        local_base_url,
+    })
+}
+
+/// Persist the public base URL advertised in OAuth metadata.
+///
+/// Pass `None` or an empty string to return to local-only localhost metadata.
+/// Non-empty values must be HTTPS origins, e.g. `https://mcp.example.com`.
+#[tauri::command]
+pub async fn set_gateway_public_base_url(
+    public_base_url: Option<String>,
+    app_state: State<'_, AppState>,
+) -> Result<(), String> {
+    let normalized = match public_base_url.as_deref() {
+        Some(raw) => normalize_public_base_url(raw)?,
+        None => None,
+    };
+
+    match normalized {
+        Some(url) => {
+            app_state
+                .settings_repository
+                .set(GATEWAY_PUBLIC_BASE_URL_KEY, &url)
+                .await
+                .map_err(|e| e.to_string())?;
+            info!("[Gateway] Persisted public base URL: {}", url);
+        }
+        None => {
+            app_state
+                .settings_repository
+                .delete(GATEWAY_PUBLIC_BASE_URL_KEY)
+                .await
+                .map_err(|e| e.to_string())?;
+            info!("[Gateway] Cleared public base URL — reverting to local-only metadata");
+        }
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn reset_gateway_public_base_url(app_state: State<'_, AppState>) -> Result<(), String> {
+    app_state
+        .settings_repository
+        .delete(GATEWAY_PUBLIC_BASE_URL_KEY)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    info!("[Gateway] Cleared public base URL — reverting to local-only metadata");
+    Ok(())
 }
 
 /// Which port source a startup attempt would use.
@@ -1266,6 +1437,7 @@ pub async fn restart_gateway(
         let handle = state.handle.take();
         state.running = false;
         state.url = None;
+        state.bound_port = None;
         handle
     };
     if let Some(h) = handle {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -419,8 +419,10 @@ pub fn run() {
                 }
 
                 let final_port = preferred_port;
-                let url = format!("http://localhost:{}", final_port);
-                info!("Auto-starting gateway on {}", url);
+                let public_base_url = crate::commands::gateway::load_public_base_url_from_repo(&settings_repo).await;
+                let url = crate::commands::gateway::advertised_base_url(public_base_url.as_deref(), final_port);
+                let local_url = format!("http://localhost:{}", final_port);
+                info!("Auto-starting gateway on {} (advertising {})", local_url, url);
 
                 // Load JWT signing secret (DPAPI on Windows, keychain elsewhere)
                 let jwt_secret = match mcpmux_storage::create_jwt_secret_provider(&app_data_dir) {
@@ -469,6 +471,7 @@ pub fn run() {
                 let config = mcpmux_gateway::GatewayConfig {
                     host: "127.0.0.1".to_string(),  // Bind address must be IP
                     port: final_port,
+                    public_base_url: public_base_url.clone(),
                     enable_cors: true,
                 };
 
@@ -525,6 +528,7 @@ pub fn run() {
                 let mut state = gw_state_clone.write().await;
                 state.running = true;
                 state.url = Some(url.clone());
+                state.bound_port = Some(final_port);
                 state.handle = Some(handle);
                 state.gateway_state = Some(gw_inner_state);
                 state.pool_service = Some(pool_service);
@@ -951,6 +955,9 @@ pub fn run() {
             commands::reset_gateway_port,
             commands::get_gateway_auth_disabled,
             commands::set_gateway_auth_disabled,
+            commands::get_gateway_public_url_settings,
+            commands::set_gateway_public_base_url,
+            commands::reset_gateway_public_base_url,
             commands::probe_gateway_start,
             commands::take_pending_port_conflict,
             commands::start_gateway,
@@ -1026,6 +1033,7 @@ pub fn run() {
                             let mut state = gw_state.write().await;
                             state.running = false;
                             state.url = None;
+                            state.bound_port = None;
                             state.handle.take()
                         };
                         if let Some(h) = handle {

--- a/apps/desktop/src/components/ConnectionCard.tsx
+++ b/apps/desktop/src/components/ConnectionCard.tsx
@@ -54,6 +54,7 @@ export function ConnectionCard() {
   const displayUrl = status.url ?? FALLBACK_URL;
   const mcpUrl = `${displayUrl}/mcp`;
   const port = extractPort(status.url);
+  const isPublicEndpoint = displayUrl.startsWith('https://');
 
   const reloadStatus = useCallback(async () => {
     try {
@@ -148,13 +149,15 @@ export function ConnectionCard() {
               {status.running && (
                 <span className="inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-[rgb(var(--muted))] px-1.5 py-0.5 rounded-md bg-[rgb(var(--surface))] border border-[rgb(var(--border-subtle))]">
                   <Lock className="h-2.5 w-2.5" />
-                  Local only
+                  {isPublicEndpoint ? 'Public tunnel' : 'Local only'}
                 </span>
               )}
             </div>
             <p className="text-xs text-[rgb(var(--muted))] mt-0.5 truncate">
               {status.running
-                ? 'Accepting IDE connections on this device.'
+                ? isPublicEndpoint
+                  ? 'Advertising the public tunnel endpoint for remote MCP clients.'
+                  : 'Accepting IDE connections on this device.'
                 : 'Start the gateway to let IDEs connect through McpMux.'}
             </p>
           </div>

--- a/apps/desktop/src/features/settings/SettingsPage.tsx
+++ b/apps/desktop/src/features/settings/SettingsPage.tsx
@@ -29,6 +29,7 @@ import {
   Package,
   Heart,
   Network,
+  Globe,
   RotateCcw,
   AlertCircle,
   ShieldOff,
@@ -54,6 +55,12 @@ interface GatewayPortSettings {
   configuredPort: number | null;
   defaultPort: number;
   activePort: number | null;
+}
+
+interface GatewayPublicUrlSettings {
+  configuredPublicBaseUrl: string | null;
+  activePublicBaseUrl: string | null;
+  localBaseUrl: string | null;
 }
 
 export function SettingsPage() {
@@ -135,6 +142,14 @@ export function SettingsPage() {
   const [savingPort, setSavingPort] = useState(false);
   const [resettingPort, setResettingPort] = useState(false);
 
+  // Public base URL — optional external HTTPS origin advertised to remote MCP
+  // clients through OAuth metadata. Leave blank for local-only localhost mode.
+  const [publicUrlSettings, setPublicUrlSettings] = useState<GatewayPublicUrlSettings | null>(null);
+  const [publicUrlDraft, setPublicUrlDraft] = useState<string>('');
+  const [publicUrlError, setPublicUrlError] = useState<string | null>(null);
+  const [savingPublicUrl, setSavingPublicUrl] = useState(false);
+  const [resettingPublicUrl, setResettingPublicUrl] = useState(false);
+
   const loadPortSettings = async () => {
     try {
       const s = await invoke<GatewayPortSettings>('get_gateway_port_settings');
@@ -146,8 +161,20 @@ export function SettingsPage() {
     }
   };
 
+  const loadPublicUrlSettings = async () => {
+    try {
+      const s = await invoke<GatewayPublicUrlSettings>('get_gateway_public_url_settings');
+      setPublicUrlSettings(s);
+      setPublicUrlDraft(s.configuredPublicBaseUrl ?? '');
+      setPublicUrlError(null);
+    } catch (err) {
+      console.error('Failed to load gateway public URL settings:', err);
+    }
+  };
+
   useEffect(() => {
     loadPortSettings();
+    loadPublicUrlSettings();
   }, []);
 
   const validatePort = (raw: string): { port: number } | { error: string } => {
@@ -159,6 +186,31 @@ export function SettingsPage() {
       return { error: 'Port must be between 1024 and 65535' };
     }
     return { port: n };
+  };
+
+  const validatePublicBaseUrl = (
+    raw: string
+  ): { publicBaseUrl: string | null } | { error: string } => {
+    const trimmed = raw.trim();
+    if (!trimmed) return { publicBaseUrl: null };
+
+    let url: URL;
+    try {
+      url = new URL(trimmed);
+    } catch {
+      return { error: 'Enter a valid HTTPS origin, for example https://mcp.example.com' };
+    }
+
+    if (url.protocol !== 'https:') return { error: 'Public base URL must start with https://' };
+    if (url.username || url.password)
+      return { error: 'Public base URL must not include credentials' };
+    if (url.search || url.hash)
+      return { error: 'Public base URL must not include a query string or fragment' };
+    if (url.pathname !== '/') {
+      return { error: 'Use the origin only, for example https://mcp.example.com, not a /mcp path' };
+    }
+
+    return { publicBaseUrl: url.origin };
   };
 
   const handleSavePort = async () => {
@@ -206,10 +258,56 @@ export function SettingsPage() {
     }
   };
 
+  const handleSavePublicUrl = async () => {
+    const parsed = validatePublicBaseUrl(publicUrlDraft);
+    if ('error' in parsed) {
+      setPublicUrlError(parsed.error);
+      return;
+    }
+
+    setPublicUrlError(null);
+    setSavingPublicUrl(true);
+    try {
+      await invoke('set_gateway_public_base_url', { publicBaseUrl: parsed.publicBaseUrl });
+      const activeAdvertised = publicUrlSettings?.activePublicBaseUrl ?? null;
+      const desiredAdvertised = parsed.publicBaseUrl ?? publicUrlSettings?.localBaseUrl ?? null;
+      await loadPublicUrlSettings();
+      success(
+        parsed.publicBaseUrl ? 'Public URL saved' : 'Public URL cleared',
+        activeAdvertised && desiredAdvertised && activeAdvertised !== desiredAdvertised
+          ? 'Restart the gateway for OAuth metadata to advertise the new URL.'
+          : parsed.publicBaseUrl
+            ? `Remote clients should use ${parsed.publicBaseUrl}/mcp.`
+            : 'Next gateway start will advertise the local localhost URL.'
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setPublicUrlError(msg);
+      error('Failed to save public URL', msg);
+    } finally {
+      setSavingPublicUrl(false);
+    }
+  };
+
+  const handleResetPublicUrl = async () => {
+    setResettingPublicUrl(true);
+    try {
+      await invoke('reset_gateway_public_base_url');
+      await loadPublicUrlSettings();
+      success('Public URL cleared', 'Restart the gateway to return OAuth metadata to localhost.');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      error('Failed to clear public URL', msg);
+    } finally {
+      setResettingPublicUrl(false);
+    }
+  };
+
   const handleRestartGateway = async () => {
     try {
       const outcome = await gatewayControl.restart();
       await loadPortSettings();
+      await loadPublicUrlSettings();
       if (outcome.status === 'cancelled') return;
       success(
         'Gateway restarted',
@@ -496,180 +594,297 @@ export function SettingsPage() {
 
         {/* Gateway Section — port override + reset to default */}
         <div ref={registerSection('gateway')} className={sectionFlashClass('gateway')}>
-        <Card data-testid="settings-gateway-section">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Network className="h-5 w-5" />
-              Gateway
-            </CardTitle>
-            <CardDescription>
-              The local port every AI client connects to. Changing it takes effect on the next
-              gateway start — existing IDE configs pointing at the old port will need updating.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {portSettings === null ? (
-              <div className="flex items-center gap-2 text-sm text-[rgb(var(--muted))]">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Loading…
-              </div>
-            ) : (
-              <div className="space-y-4">
-                <div className="flex items-start gap-3">
-                  <Network className="mt-0.5 h-5 w-5 flex-shrink-0 text-[rgb(var(--muted))]" />
-                  <div className="min-w-0 flex-1">
-                    <label htmlFor="gateway-port-input" className="text-sm font-medium">
-                      Gateway port
-                    </label>
-                    <p className="mt-1 text-xs text-[rgb(var(--muted))]">
-                      Default is <span className="font-mono">{portSettings.defaultPort}</span>. Use
-                      a port between 1024 and 65535.
-                      {portSettings.activePort !== null ? (
-                        <>
-                          {' '}
-                          Currently running on{' '}
-                          <span className="font-mono" data-testid="gateway-active-port">
-                            :{portSettings.activePort}
-                          </span>
-                          .
-                        </>
-                      ) : (
-                        ' Gateway is stopped.'
-                      )}
-                    </p>
-                    <div className="mt-3 flex flex-wrap items-center gap-2">
-                      <input
-                        id="gateway-port-input"
-                        type="number"
-                        inputMode="numeric"
-                        min={1024}
-                        max={65535}
-                        value={portDraft}
-                        onChange={(e) => {
-                          setPortDraft(e.target.value);
-                          if (portError) setPortError(null);
-                        }}
-                        disabled={savingPort || resettingPort}
-                        className="focus:ring-primary-500/40 w-28 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-1.5 font-mono text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-2"
-                        data-testid="gateway-port-input"
-                      />
-                      <Button
-                        variant="primary"
-                        size="sm"
-                        onClick={handleSavePort}
-                        disabled={
-                          savingPort ||
-                          resettingPort ||
-                          portDraft.trim() ===
-                            String(portSettings.configuredPort ?? portSettings.defaultPort)
-                        }
-                        data-testid="gateway-port-save-btn"
-                      >
-                        {savingPort ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-                        Save
-                      </Button>
+          <Card data-testid="settings-gateway-section">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Network className="h-5 w-5" />
+                Gateway
+              </CardTitle>
+              <CardDescription>
+                The local port every AI client connects to. Changing it takes effect on the next
+                gateway start — existing IDE configs pointing at the old port will need updating.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {portSettings === null ? (
+                <div className="flex items-center gap-2 text-sm text-[rgb(var(--muted))]">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Loading…
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  <div className="flex items-start gap-3">
+                    <Network className="mt-0.5 h-5 w-5 flex-shrink-0 text-[rgb(var(--muted))]" />
+                    <div className="min-w-0 flex-1">
+                      <label htmlFor="gateway-port-input" className="text-sm font-medium">
+                        Gateway port
+                      </label>
+                      <p className="mt-1 text-xs text-[rgb(var(--muted))]">
+                        Default is <span className="font-mono">{portSettings.defaultPort}</span>.
+                        Use a port between 1024 and 65535.
+                        {portSettings.activePort !== null ? (
+                          <>
+                            {' '}
+                            Currently running on{' '}
+                            <span className="font-mono" data-testid="gateway-active-port">
+                              :{portSettings.activePort}
+                            </span>
+                            .
+                          </>
+                        ) : (
+                          ' Gateway is stopped.'
+                        )}
+                      </p>
+                      <div className="mt-3 flex flex-wrap items-center gap-2">
+                        <input
+                          id="gateway-port-input"
+                          type="number"
+                          inputMode="numeric"
+                          min={1024}
+                          max={65535}
+                          value={portDraft}
+                          onChange={(e) => {
+                            setPortDraft(e.target.value);
+                            if (portError) setPortError(null);
+                          }}
+                          disabled={savingPort || resettingPort}
+                          className="focus:ring-primary-500/40 w-28 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-1.5 font-mono text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-2"
+                          data-testid="gateway-port-input"
+                        />
+                        <Button
+                          variant="primary"
+                          size="sm"
+                          onClick={handleSavePort}
+                          disabled={
+                            savingPort ||
+                            resettingPort ||
+                            portDraft.trim() ===
+                              String(portSettings.configuredPort ?? portSettings.defaultPort)
+                          }
+                          data-testid="gateway-port-save-btn"
+                        >
+                          {savingPort ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                          Save
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={handleResetPort}
+                          disabled={
+                            savingPort || resettingPort || portSettings.configuredPort === null
+                          }
+                          data-testid="gateway-port-reset-btn"
+                          title={
+                            portSettings.configuredPort === null
+                              ? 'Already using the default port'
+                              : `Reset to ${portSettings.defaultPort}`
+                          }
+                        >
+                          {resettingPort ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          ) : (
+                            <RotateCcw className="mr-2 h-4 w-4" />
+                          )}
+                          Reset to default
+                        </Button>
+                      </div>
+                      {portError ? (
+                        <p
+                          className="mt-2 text-xs text-red-600 dark:text-red-400"
+                          data-testid="gateway-port-error"
+                        >
+                          {portError}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <div className="border-t border-[rgb(var(--border-subtle))] pt-4">
+                    <div className="flex items-start gap-3">
+                      <Globe className="mt-0.5 h-5 w-5 flex-shrink-0 text-[rgb(var(--muted))]" />
+                      <div className="min-w-0 flex-1">
+                        <label htmlFor="gateway-public-url-input" className="text-sm font-medium">
+                          Public base URL
+                        </label>
+                        <p className="mt-1 text-xs text-[rgb(var(--muted))]">
+                          Optional HTTPS origin to advertise in OAuth metadata when the gateway sits
+                          behind a public tunnel. Use{' '}
+                          <span className="font-mono">https://mcp.example.com</span>, not{' '}
+                          <span className="font-mono">/mcp</span>. Leave blank for local-only mode.
+                          {publicUrlSettings?.activePublicBaseUrl ? (
+                            <>
+                              {' '}
+                              Currently advertising{' '}
+                              <span className="font-mono" data-testid="gateway-active-public-url">
+                                {publicUrlSettings.activePublicBaseUrl}
+                              </span>
+                              .
+                            </>
+                          ) : null}
+                        </p>
+                        <div className="mt-3 flex flex-wrap items-center gap-2">
+                          <input
+                            id="gateway-public-url-input"
+                            type="url"
+                            inputMode="url"
+                            placeholder="https://mcp.example.com"
+                            value={publicUrlDraft}
+                            onChange={(e) => {
+                              setPublicUrlDraft(e.target.value);
+                              if (publicUrlError) setPublicUrlError(null);
+                            }}
+                            disabled={savingPublicUrl || resettingPublicUrl}
+                            className="focus:ring-primary-500/40 min-w-[280px] flex-1 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-1.5 font-mono text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-2"
+                            data-testid="gateway-public-url-input"
+                          />
+                          <Button
+                            variant="primary"
+                            size="sm"
+                            onClick={handleSavePublicUrl}
+                            disabled={
+                              savingPublicUrl ||
+                              resettingPublicUrl ||
+                              publicUrlDraft.trim().replace(/\/+$/, '') ===
+                                (publicUrlSettings?.configuredPublicBaseUrl ?? '')
+                            }
+                            data-testid="gateway-public-url-save-btn"
+                          >
+                            {savingPublicUrl ? (
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            ) : null}
+                            Save
+                          </Button>
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            onClick={handleResetPublicUrl}
+                            disabled={
+                              savingPublicUrl ||
+                              resettingPublicUrl ||
+                              publicUrlSettings?.configuredPublicBaseUrl === null
+                            }
+                            data-testid="gateway-public-url-reset-btn"
+                          >
+                            {resettingPublicUrl ? (
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            ) : (
+                              <RotateCcw className="mr-2 h-4 w-4" />
+                            )}
+                            Clear
+                          </Button>
+                        </div>
+                        {publicUrlError ? (
+                          <p
+                            className="mt-2 text-xs text-red-600 dark:text-red-400"
+                            data-testid="gateway-public-url-error"
+                          >
+                            {publicUrlError}
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                  </div>
+
+                  {publicUrlSettings?.activePublicBaseUrl &&
+                  (publicUrlSettings.configuredPublicBaseUrl ?? publicUrlSettings.localBaseUrl) &&
+                  publicUrlSettings.activePublicBaseUrl !==
+                    (publicUrlSettings.configuredPublicBaseUrl ??
+                      publicUrlSettings.localBaseUrl) ? (
+                    <div
+                      className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs dark:border-amber-700/60 dark:bg-amber-900/20"
+                      data-testid="gateway-public-url-restart-hint"
+                    >
+                      <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+                      <div className="flex-1">
+                        <p className="font-semibold text-amber-800 dark:text-amber-200">
+                          Restart required
+                        </p>
+                        <p className="mt-0.5 text-amber-700 dark:text-amber-300">
+                          The saved public URL does not match the URL currently advertised in OAuth
+                          metadata. Restart the gateway before reconnecting ChatGPT.
+                        </p>
+                      </div>
                       <Button
                         variant="secondary"
                         size="sm"
-                        onClick={handleResetPort}
-                        disabled={
-                          savingPort || resettingPort || portSettings.configuredPort === null
-                        }
-                        data-testid="gateway-port-reset-btn"
-                        title={
-                          portSettings.configuredPort === null
-                            ? 'Already using the default port'
-                            : `Reset to ${portSettings.defaultPort}`
-                        }
+                        onClick={handleRestartGateway}
+                        data-testid="gateway-public-url-restart-btn"
                       >
-                        {resettingPort ? (
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        ) : (
-                          <RotateCcw className="mr-2 h-4 w-4" />
-                        )}
-                        Reset to default
+                        Restart gateway
                       </Button>
                     </div>
-                    {portError ? (
-                      <p
-                        className="mt-2 text-xs text-red-600 dark:text-red-400"
-                        data-testid="gateway-port-error"
-                      >
-                        {portError}
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
+                  ) : null}
 
-                {portSettings.activePort !== null &&
-                portSettings.configuredPort !== null &&
-                portSettings.configuredPort !== portSettings.activePort ? (
-                  <div
-                    className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs dark:border-amber-700/60 dark:bg-amber-900/20"
-                    data-testid="gateway-port-restart-hint"
-                  >
-                    <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
-                    <div className="flex-1">
-                      <p className="font-semibold text-amber-800 dark:text-amber-200">
-                        Restart required
-                      </p>
-                      <p className="mt-0.5 text-amber-700 dark:text-amber-300">
-                        Saved port <span className="font-mono">:{portSettings.configuredPort}</span>{' '}
-                        doesn't match the running port{' '}
-                        <span className="font-mono">:{portSettings.activePort}</span>. Restart the
-                        gateway to apply — your IDE configs will need to point at the new URL.
-                      </p>
-                    </div>
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={handleRestartGateway}
-                      data-testid="gateway-restart-btn"
+                  {portSettings.activePort !== null &&
+                  portSettings.configuredPort !== null &&
+                  portSettings.configuredPort !== portSettings.activePort ? (
+                    <div
+                      className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs dark:border-amber-700/60 dark:bg-amber-900/20"
+                      data-testid="gateway-port-restart-hint"
                     >
-                      Restart gateway
-                    </Button>
-                  </div>
-                ) : null}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+                      <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+                      <div className="flex-1">
+                        <p className="font-semibold text-amber-800 dark:text-amber-200">
+                          Restart required
+                        </p>
+                        <p className="mt-0.5 text-amber-700 dark:text-amber-300">
+                          Saved port{' '}
+                          <span className="font-mono">:{portSettings.configuredPort}</span> doesn't
+                          match the running port{' '}
+                          <span className="font-mono">:{portSettings.activePort}</span>. Restart the
+                          gateway to apply — your IDE configs will need to point at the new URL.
+                        </p>
+                      </div>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={handleRestartGateway}
+                        data-testid="gateway-restart-btn"
+                      >
+                        Restart gateway
+                      </Button>
+                    </div>
+                  ) : null}
+                </div>
+              )}
+            </CardContent>
+          </Card>
         </div>
 
         {/* Workspaces Section */}
         <div ref={registerSection('workspaces')} className={sectionFlashClass('workspaces')}>
-        <Card data-testid="settings-workspaces-section">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <FolderOpen className="h-5 w-5" />
-              Workspaces
-            </CardTitle>
-            <CardDescription>
-              How McpMux handles folders your connected apps open.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center justify-between gap-4">
-              <div className="flex min-w-0 flex-1 items-start gap-3">
-                <FolderOpen className="mt-0.5 h-5 w-5 flex-shrink-0 text-[rgb(var(--muted))]" />
-                <div>
-                  <label className="text-sm font-medium">Ask to map new folders</label>
-                  <p className="mt-1 text-xs text-[rgb(var(--muted))]">
-                    When a connected app opens a folder you haven't mapped, show a prompt to give
-                    it a specific feature set. The folder already works with your default Starter
-                    set either way.
-                  </p>
+          <Card data-testid="settings-workspaces-section">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <FolderOpen className="h-5 w-5" />
+                Workspaces
+              </CardTitle>
+              <CardDescription>
+                How McpMux handles folders your connected apps open.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex min-w-0 flex-1 items-start gap-3">
+                  <FolderOpen className="mt-0.5 h-5 w-5 flex-shrink-0 text-[rgb(var(--muted))]" />
+                  <div>
+                    <label className="text-sm font-medium">Ask to map new folders</label>
+                    <p className="mt-1 text-xs text-[rgb(var(--muted))]">
+                      When a connected app opens a folder you haven't mapped, show a prompt to give
+                      it a specific feature set. The folder already works with your default Starter
+                      set either way.
+                    </p>
+                  </div>
                 </div>
+                <Switch
+                  checked={mappingPromptEnabled}
+                  onCheckedChange={updateMappingPrompt}
+                  disabled={savingMappingPrompt}
+                  data-testid="workspace-mapping-prompt-switch"
+                />
               </div>
-              <Switch
-                checked={mappingPromptEnabled}
-                onCheckedChange={updateMappingPrompt}
-                disabled={savingMappingPrompt}
-                data-testid="workspace-mapping-prompt-switch"
-              />
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
         </div>
 
         {/* Security Section */}
@@ -678,37 +893,38 @@ export function SettingsPage() {
           id="settings-security"
           className={sectionFlashClass('security')}
         >
-        <Card data-testid="settings-security-section">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <ShieldOff className="h-5 w-5" />
-              Security
-            </CardTitle>
-            <CardDescription>
-              How McpMux authenticates apps connecting to the local gateway.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center justify-between gap-4">
-              <div className="flex min-w-0 flex-1 items-start gap-3">
-                <ShieldOff className="mt-0.5 h-5 w-5 flex-shrink-0 text-[rgb(var(--muted))]" />
-                <div>
-                  <label className="text-sm font-medium">Disable authentication</label>
-                  <p className="mt-1 text-xs text-[rgb(var(--muted))]">
-                    Let local apps connect with no access key — just the URL and a workspace header.
-                    Quickest setup, but any app on this machine can then reach the gateway.
-                  </p>
+          <Card data-testid="settings-security-section">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ShieldOff className="h-5 w-5" />
+                Security
+              </CardTitle>
+              <CardDescription>
+                How McpMux authenticates apps connecting to the local gateway.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex min-w-0 flex-1 items-start gap-3">
+                  <ShieldOff className="mt-0.5 h-5 w-5 flex-shrink-0 text-[rgb(var(--muted))]" />
+                  <div>
+                    <label className="text-sm font-medium">Disable authentication</label>
+                    <p className="mt-1 text-xs text-[rgb(var(--muted))]">
+                      Let local apps connect with no access key — just the URL and a workspace
+                      header. Quickest setup, but any app on this machine can then reach the
+                      gateway.
+                    </p>
+                  </div>
                 </div>
+                <Switch
+                  checked={authDisabled}
+                  onCheckedChange={updateAuthDisabled}
+                  disabled={savingAuthDisabled}
+                  data-testid="disable-auth-switch"
+                />
               </div>
-              <Switch
-                checked={authDisabled}
-                onCheckedChange={updateAuthDisabled}
-                disabled={savingAuthDisabled}
-                data-testid="disable-auth-switch"
-              />
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
         </div>
 
         {/* Appearance Section */}

--- a/apps/desktop/src/lib/api/gateway.ts
+++ b/apps/desktop/src/lib/api/gateway.ts
@@ -11,6 +11,15 @@ export interface GatewayStatus {
 }
 
 /**
+ * Public URL advertised by the gateway in OAuth metadata.
+ */
+export interface GatewayPublicUrlSettings {
+  configuredPublicBaseUrl: string | null;
+  activePublicBaseUrl: string | null;
+  localBaseUrl: string | null;
+}
+
+/**
  * Config export format.
  */
 export type ExportFormat = 'cursor' | 'vscode' | 'claude';
@@ -20,6 +29,27 @@ export type ExportFormat = 'cursor' | 'vscode' | 'claude';
  */
 export async function getGatewayStatus(spaceId?: string): Promise<GatewayStatus> {
   return invoke('get_gateway_status', { spaceId });
+}
+
+/**
+ * Get the configured and currently-active public gateway URL settings.
+ */
+export async function getGatewayPublicUrlSettings(): Promise<GatewayPublicUrlSettings> {
+  return invoke('get_gateway_public_url_settings');
+}
+
+/**
+ * Set the public base URL advertised in OAuth metadata. Pass null to clear it.
+ */
+export async function setGatewayPublicBaseUrl(publicBaseUrl: string | null): Promise<void> {
+  return invoke('set_gateway_public_base_url', { publicBaseUrl });
+}
+
+/**
+ * Clear the public base URL and return to local-only localhost metadata.
+ */
+export async function resetGatewayPublicBaseUrl(): Promise<void> {
+  return invoke('reset_gateway_public_base_url');
 }
 
 /**

--- a/crates/mcpmux-gateway/src/auth/mod.rs
+++ b/crates/mcpmux-gateway/src/auth/mod.rs
@@ -453,7 +453,7 @@ pub async fn oauth_auth_middleware(
 /// parameter pointing to the OAuth Protected Resource Metadata endpoint.
 fn unauthorized_response_with_url(base_url: &str, error: &str, description: &str) -> Response {
     // RFC 9728: Protected Resource Metadata URL
-    let resource_metadata_url = format!("{}/.well-known/oauth-protected-resource", base_url);
+    let resource_metadata_url = format!("{}/.well-known/oauth-protected-resource/mcp", base_url);
 
     // WWW-Authenticate header per RFC 9728
     let www_authenticate = format!(

--- a/crates/mcpmux-gateway/src/mcp/oauth_middleware.rs
+++ b/crates/mcpmux-gateway/src/mcp/oauth_middleware.rs
@@ -7,7 +7,7 @@
 
 use axum::{
     body::Body,
-    http::{Request, Response, StatusCode},
+    http::{header, Request, Response, StatusCode},
     middleware::Next,
     response::IntoResponse,
 };
@@ -44,6 +44,11 @@ pub async fn mcp_oauth_middleware(
         .map(|ctx| ctx.trace_id.clone())
         .unwrap_or_else(|| "??????".to_string());
 
+    let base_url = {
+        let state = services.gateway_state.read().await;
+        state.base_url.clone()
+    };
+
     // System-wide inbound auth can be disabled (localhost-only convenience):
     // when off, a connection is accepted without a Bearer token and routed by
     // the workspace header / default space. A valid token is still honored when
@@ -53,7 +58,7 @@ pub async fn mcp_oauth_middleware(
 
     let auth_header = request
         .headers()
-        .get("authorization")
+        .get(header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
         .map(str::to_owned);
     let token = auth_header
@@ -108,7 +113,7 @@ pub async fn mcp_oauth_middleware(
             _ => "Invalid token",
         };
         warn!(trace_id = %trace_id, "{}", msg);
-        return unauthorized_response(msg);
+        return unauthorized_response(&base_url, msg);
     } else {
         // Auth disabled → accept anonymously on the default space. Routing
         // still prefers the workspace header (pinned below) → binding.
@@ -224,15 +229,26 @@ pub async fn mcp_oauth_middleware(
     response
 }
 
-/// Generate unauthorized response
-fn unauthorized_response(message: &str) -> Response<Body> {
+/// Generate unauthorized response with RFC 9728 protected-resource discovery.
+fn unauthorized_response(base_url: &str, message: &str) -> Response<Body> {
+    let resource_metadata_url = format!(
+        "{}/.well-known/oauth-protected-resource/mcp",
+        base_url.trim_end_matches('/')
+    );
+    let www_authenticate = format!(
+        r#"Bearer realm="McpMux Gateway", error="invalid_token", error_description="{}", resource_metadata="{}""#,
+        message, resource_metadata_url
+    );
+    let body = serde_json::json!({
+        "error": "invalid_token",
+        "error_description": message,
+        "resource_metadata": resource_metadata_url,
+    });
+
     (
         StatusCode::UNAUTHORIZED,
-        [(
-            "WWW-Authenticate",
-            r#"Bearer realm="McpMux Gateway", error="invalid_token""#,
-        )],
-        message.to_string(),
+        [(header::WWW_AUTHENTICATE, www_authenticate)],
+        axum::Json(body),
     )
         .into_response()
 }

--- a/crates/mcpmux-gateway/src/server/mod.rs
+++ b/crates/mcpmux-gateway/src/server/mod.rs
@@ -623,3 +623,60 @@ impl GatewayServerHandle {
         self.shutdown.is_some()
     }
 }
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+
+    fn config_with(public: Option<&str>) -> GatewayConfig {
+        GatewayConfig {
+            public_base_url: public.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn base_url_defaults_to_localhost() {
+        let cfg = config_with(None);
+        assert_eq!(cfg.base_url(), format!("http://localhost:{}", cfg.port));
+    }
+
+    #[test]
+    fn base_url_uses_public_origin_and_trims_trailing_slash() {
+        assert_eq!(
+            config_with(Some("https://mcp.example.com/")).base_url(),
+            "https://mcp.example.com"
+        );
+    }
+
+    #[test]
+    fn allowed_hosts_always_include_loopback() {
+        let hosts = config_with(None).allowed_hosts();
+        for h in ["localhost", "127.0.0.1", "::1"] {
+            assert!(hosts.contains(&h.to_string()), "missing {h} in {hosts:?}");
+        }
+    }
+
+    #[test]
+    fn allowed_hosts_include_public_host_and_optional_port() {
+        let hosts = config_with(Some("https://mcp.example.com")).allowed_hosts();
+        assert!(hosts.contains(&"mcp.example.com".to_string()), "{hosts:?}");
+
+        let hosts_port = config_with(Some("https://mcp.example.com:8443")).allowed_hosts();
+        assert!(
+            hosts_port.contains(&"mcp.example.com".to_string()),
+            "{hosts_port:?}"
+        );
+        assert!(
+            hosts_port.contains(&"mcp.example.com:8443".to_string()),
+            "{hosts_port:?}"
+        );
+    }
+
+    #[test]
+    fn allowed_hosts_ignores_invalid_public_url_without_panicking() {
+        let hosts = config_with(Some("not a url")).allowed_hosts();
+        assert!(hosts.contains(&"localhost".to_string()));
+        assert!(!hosts.iter().any(|h| h.contains("not a url")));
+    }
+}

--- a/crates/mcpmux-gateway/src/server/mod.rs
+++ b/crates/mcpmux-gateway/src/server/mod.rs
@@ -54,6 +54,13 @@ pub struct GatewayConfig {
     pub host: String,
     /// Port to listen on
     pub port: u16,
+    /// Public base URL advertised in OAuth metadata.
+    ///
+    /// When unset, the gateway behaves as a local-only server and advertises
+    /// `http://localhost:<port>`. When set, this must be the externally
+    /// reachable origin fronting the gateway, for example a Cloudflare Tunnel
+    /// URL such as `https://mcp.example.com`.
+    pub public_base_url: Option<String>,
     /// Enable CORS for browser access
     pub enable_cors: bool,
 }
@@ -63,6 +70,7 @@ impl Default for GatewayConfig {
         Self {
             host: "127.0.0.1".to_string(),
             port: mcpmux_core::branding::DEFAULT_GATEWAY_PORT,
+            public_base_url: None,
             enable_cors: true,
         }
     }
@@ -76,10 +84,61 @@ impl GatewayConfig {
             .expect("Invalid address")
     }
 
-    /// Get the base URL for this gateway
-    /// Uses localhost for consistency with client configurations
+    /// Get the base URL this gateway advertises to MCP/OAuth clients.
     pub fn base_url(&self) -> String {
-        format!("http://localhost:{}", self.port)
+        self.public_base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|url| !url.is_empty())
+            .map(|url| url.trim_end_matches('/').to_string())
+            .unwrap_or_else(|| format!("http://localhost:{}", self.port))
+    }
+
+    /// Host values accepted by rmcp's DNS rebinding protection.
+    ///
+    /// rmcp's Streamable HTTP service defaults to loopback-only Host headers.
+    /// When the gateway is published through a reverse proxy or Cloudflare
+    /// Tunnel, ChatGPT reaches it with the public host, so that hostname must
+    /// be explicitly allowlisted.
+    pub fn allowed_hosts(&self) -> Vec<String> {
+        let mut hosts = vec![
+            "localhost".to_string(),
+            "127.0.0.1".to_string(),
+            "::1".to_string(),
+        ];
+
+        let bind_host = self.host.trim();
+        if !bind_host.is_empty() {
+            hosts.push(bind_host.to_string());
+            hosts.push(format!("{}:{}", bind_host, self.port));
+        }
+
+        if let Some(public_base_url) = self.public_base_url.as_deref() {
+            let trimmed = public_base_url.trim();
+            if !trimmed.is_empty() {
+                match url::Url::parse(trimmed) {
+                    Ok(parsed) => {
+                        if let Some(host) = parsed.host_str() {
+                            hosts.push(host.to_string());
+                            if let Some(port) = parsed.port() {
+                                hosts.push(format!("{}:{}", host, port));
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        warn!(
+                            public_base_url = trimmed,
+                            error = %error,
+                            "[Gateway] Ignoring invalid public_base_url for allowed host list"
+                        );
+                    }
+                }
+            }
+        }
+
+        hosts.sort();
+        hosts.dedup();
+        hosts
     }
 }
 
@@ -277,6 +336,11 @@ impl GatewayServer {
         let mut http_cfg = StreamableHttpServerConfig::default();
         http_cfg.stateful_mode = true;
         http_cfg.json_response = false;
+        http_cfg.allowed_hosts = self.config.allowed_hosts();
+        info!(
+            "[Gateway] MCP allowed Host headers: {:?}",
+            http_cfg.allowed_hosts
+        );
         http_cfg.sse_keep_alive = Some(std::time::Duration::from_secs(30));
         http_cfg.sse_retry = Some(std::time::Duration::from_secs(3));
         http_cfg.cancellation_token = CancellationToken::new();
@@ -314,6 +378,12 @@ impl GatewayServer {
             // OAuth endpoints (public) - use app_state for base_url access
             .route(
                 "/.well-known/oauth-authorization-server",
+                get(handlers::oauth_metadata),
+            )
+            // Some remote MCP clients, including ChatGPT connector flows, probe
+            // the resource-scoped authorization-server metadata path.
+            .route(
+                "/.well-known/oauth-authorization-server/mcp",
                 get(handlers::oauth_metadata),
             )
             .route(


### PR DESCRIPTION
## Summary

Adds an optional, persisted public gateway base URL for deployments where the local gateway is fronted by a tunnel or reverse proxy.

What changes:

- Adds a Settings UI control for a public HTTPS origin, using the neutral example `https://mcp.example.com`.
- Keeps the gateway bound locally while advertising the configured public origin in OAuth/MCP metadata.
- Adds the configured public host to rmcp Streamable HTTP allowed hosts so proxied requests are accepted.
- Updates RFC 9728 protected-resource metadata and unauthorized responses to advertise the `/mcp` resource metadata URL.
- Shows when the active gateway endpoint is a public tunnel rather than local-only.

This is intentionally separate from the DCR redirect URI PR. If CI requires `--locked`, the lockfile-only PR should land first: https://github.com/mcpmux/mcp-mux/pull/191

## Testing

- `cargo check --workspace`
- `cargo test -p tests --test streamable_http auth_ -- --nocapture`
- `pnpm typecheck`
