### PR TITLE
fix: sync custom server config saves immediately

### DIFF
--- a/apps/desktop/src-tauri/src/commands/space.rs
+++ b/apps/desktop/src-tauri/src/commands/space.rs
@@ -6,7 +6,10 @@
 //! built-in fallback. The desktop UI tracks which space the user is
 //! viewing in its own Zustand store (frontend-only state).
 
-use mcpmux_core::{validate_workspace_root, Space, SpaceBaseDir, WorkspaceRootValidation};
+use mcpmux_core::{
+    application::UserSpaceSyncService, validate_workspace_root, Space, SpaceBaseDir,
+    WorkspaceRootValidation,
+};
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 use tokio::sync::RwLock;
@@ -193,7 +196,28 @@ pub async fn save_space_config(
     serde_json::from_str::<serde_json::Value>(&content)
         .map_err(|e| format!("Invalid JSON: {}", e))?;
 
-    std::fs::write(&config_path, content).map_err(|e| format!("Failed to write config file: {}", e))
+    std::fs::write(&config_path, content)
+        .map_err(|e| format!("Failed to write config file: {}", e))?;
+
+    // Do not rely solely on the debounced file watcher. The UI reloads immediately
+    // after this command returns, so sync the just-saved file into InstalledServer
+    // records synchronously to avoid stale/missing custom-server state.
+    let sync_service = UserSpaceSyncService::new(state.installed_server_repository.clone());
+    let sync_result = sync_service
+        .sync_from_file(&space_id, &config_path)
+        .await
+        .map_err(|e| format!("Failed to sync custom server config: {}", e))?;
+
+    if sync_result.has_changes() {
+        info!(
+            "[save_space_config] Synced custom server config: {} added, {} updated, {} removed",
+            sync_result.added.len(),
+            sync_result.updated.len(),
+            sync_result.removed.len()
+        );
+    }
+
+    Ok(())
 }
 
 /// Remove a server from the space configuration file

--- a/apps/desktop/src/components/ConfigEditorModal.tsx
+++ b/apps/desktop/src/components/ConfigEditorModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { X, Save, Loader2, AlertTriangle, Wand2 } from 'lucide-react';
+import { X, Save, Loader2, AlertTriangle, Wand2, Plus } from 'lucide-react';
 import { readSpaceConfig, saveSpaceConfig } from '@/lib/api/spaces';
 import { refreshRegistry } from '@/lib/api/registry';
 import Editor, { type Monaco } from '@monaco-editor/react';
@@ -11,11 +11,56 @@ import { RequestServerCTA } from './Contribute';
 interface ConfigEditorModalProps {
   spaceId: string;
   spaceName: string;
+  insertNewServer?: boolean;
   onClose: () => void;
   onSaved: () => void;
 }
 
-export function ConfigEditorModal({ spaceId, spaceName, onClose, onSaved }: ConfigEditorModalProps) {
+type SpaceConfigJson = {
+  mcpServers?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+const CUSTOM_SERVER_BASE_KEY = 'custom-server';
+
+function nextCustomServerKey(servers: Record<string, unknown>): string {
+  let suffix = 1;
+
+  while (true) {
+    const key = suffix === 1 ? CUSTOM_SERVER_BASE_KEY : CUSTOM_SERVER_BASE_KEY + '-' + suffix;
+    if (!(key in servers)) {
+      return key;
+    }
+    suffix += 1;
+  }
+}
+
+function addCustomServerDraft(config: SpaceConfigJson): SpaceConfigJson {
+  const mcpServers = { ...(config.mcpServers ?? {}) };
+  const key = nextCustomServerKey(mcpServers);
+  const suffix =
+    key === CUSTOM_SERVER_BASE_KEY ? '' : ' ' + key.replace(CUSTOM_SERVER_BASE_KEY + '-', '');
+
+  mcpServers[key] = {
+    name: 'New Custom Server' + suffix,
+    command: '',
+    args: [],
+    env: {},
+  };
+
+  return {
+    ...config,
+    mcpServers,
+  };
+}
+
+export function ConfigEditorModal({
+  spaceId,
+  spaceName,
+  insertNewServer = false,
+  onClose,
+  onSaved,
+}: ConfigEditorModalProps) {
   const [content, setContent] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -35,17 +80,19 @@ export function ConfigEditorModal({ spaceId, spaceName, onClose, onSaved }: Conf
 
   useEffect(() => {
     loadConfig();
-  }, [spaceId]);
+  }, [spaceId, insertNewServer]);
 
   const loadConfig = async () => {
     try {
       setIsLoading(true);
       setError(null);
       const data = await readSpaceConfig(spaceId);
-      // Auto-format on load if valid JSON
+      // Auto-format on load if valid JSON. When opened from Add Custom Server,
+      // insert a unique draft entry instead of replacing an existing server block.
       try {
-        const parsed = JSON.parse(data);
-        setContent(JSON.stringify(parsed, null, 2));
+        const parsed = JSON.parse(data) as SpaceConfigJson;
+        const nextConfig = insertNewServer ? addCustomServerDraft(parsed) : parsed;
+        setContent(JSON.stringify(nextConfig, null, 2));
       } catch {
         setContent(data);
       }
@@ -73,7 +120,7 @@ export function ConfigEditorModal({ spaceId, spaceName, onClose, onSaved }: Conf
       await saveSpaceConfig(spaceId, content);
       // Refresh server discovery to pick up new/changed servers
       await refreshRegistry();
-      
+
       success('Configuration saved', 'Space configuration updated successfully');
       onSaved();
       onClose();
@@ -92,6 +139,20 @@ export function ConfigEditorModal({ spaceId, spaceName, onClose, onSaved }: Conf
       editorRef.current.getAction('editor.action.formatDocument')?.run();
     }
   }, []);
+
+  const handleInsertCustomServer = useCallback(() => {
+    try {
+      const parsed = JSON.parse(content || '{"mcpServers":{}}') as SpaceConfigJson;
+      setContent(JSON.stringify(addCustomServerDraft(parsed), null, 2));
+      setIsValidJson(true);
+      setError(null);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setIsValidJson(false);
+      setError('Invalid JSON: ' + message);
+      showError('Invalid JSON', message);
+    }
+  }, [content, showError]);
 
   // Configure Monaco before mount to set up JSON schema validation
   const handleEditorBeforeMount = (monaco: Monaco) => {
@@ -114,13 +175,13 @@ export function ConfigEditorModal({ spaceId, spaceName, onClose, onSaved }: Conf
   const handleEditorMount = (editor: editor.IStandaloneCodeEditor, monaco: Monaco) => {
     editorRef.current = editor;
     monacoRef.current = monaco;
-    
+
     // Focus editor on mount
     editor.focus();
   };
 
   const handleEditorValidation = (markers: editor.IMarker[]) => {
-    const errors = markers.map(m => `Line ${m.startLineNumber}: ${m.message}`);
+    const errors = markers.map((m) => `Line ${m.startLineNumber}: ${m.message}`);
     setValidationErrors(errors);
     setIsValidJson(markers.length === 0);
   };
@@ -159,128 +220,141 @@ export function ConfigEditorModal({ spaceId, spaceName, onClose, onSaved }: Conf
 
   return (
     <>
-      <ToastContainer toasts={toasts} onClose={(id) => toasts.find(t => t.id === id)?.onClose(id)} />
-      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-[rgb(var(--surface))] w-full max-w-4xl h-[80vh] rounded-xl shadow-2xl flex flex-col border border-[rgb(var(--border))]">
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-[rgb(var(--border))]">
-          <div className="flex items-center gap-3">
-            <div className="w-9 h-9 flex items-center justify-center rounded-lg bg-[rgb(var(--primary))]/10 border border-[rgb(var(--primary))]/20">
-              <Save className="h-4 w-4 text-[rgb(var(--primary))]" />
+      <ToastContainer
+        toasts={toasts}
+        onClose={(id) => toasts.find((t) => t.id === id)?.onClose(id)}
+      />
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
+        <div className="flex h-[80vh] w-full max-w-4xl flex-col rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))] shadow-2xl">
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-[rgb(var(--border))] p-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-[rgb(var(--primary))]/20 bg-[rgb(var(--primary))]/10">
+                <Save className="h-4 w-4 text-[rgb(var(--primary))]" />
+              </div>
+              <div>
+                <h3 className="text-base font-semibold">Custom Server Configuration</h3>
+                <p className="text-xs text-[rgb(var(--muted))]">{spaceName} &middot; JSON config</p>
+              </div>
             </div>
-            <div>
-              <h3 className="text-base font-semibold">
-                Custom Server Configuration
-              </h3>
-              <p className="text-xs text-[rgb(var(--muted))]">
-                {spaceName} &middot; JSON config
-              </p>
-            </div>
+            <button
+              onClick={onClose}
+              className="rounded-lg p-2 transition-colors hover:bg-[rgb(var(--surface-hover))]"
+            >
+              <X className="h-5 w-5 text-[rgb(var(--muted))]" />
+            </button>
           </div>
-          <button
-            onClick={onClose}
-            className="p-2 hover:bg-[rgb(var(--surface-hover))] rounded-lg transition-colors"
-          >
-            <X className="h-5 w-5 text-[rgb(var(--muted))]" />
-          </button>
-        </div>
 
-        {/* Toolbar */}
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-[rgb(var(--border))] bg-[rgb(var(--surface-dim))]">
-          <button
-            onClick={handleSave}
-            disabled={isSaving || isLoading || !isValidJson}
-            className="flex items-center gap-2 px-3.5 py-1.5 text-sm font-medium bg-[rgb(var(--primary))] text-[rgb(var(--primary-foreground))] rounded-lg hover:bg-[rgb(var(--primary-hover))] disabled:opacity-50 shadow-sm transition-colors"
-          >
-            {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-            Save
-          </button>
+          {/* Toolbar */}
+          <div className="flex items-center gap-2 border-b border-[rgb(var(--border))] bg-[rgb(var(--surface-dim))] px-3 py-2">
+            <button
+              onClick={handleSave}
+              disabled={isSaving || isLoading || !isValidJson}
+              className="flex items-center gap-2 rounded-lg bg-[rgb(var(--primary))] px-3.5 py-1.5 text-sm font-medium text-[rgb(var(--primary-foreground))] shadow-sm transition-colors hover:bg-[rgb(var(--primary-hover))] disabled:opacity-50"
+            >
+              {isSaving ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Save className="h-4 w-4" />
+              )}
+              Save
+            </button>
 
-          <div className="h-5 w-px bg-[rgb(var(--border))]" />
+            <div className="h-5 w-px bg-[rgb(var(--border))]" />
 
-          <button
-            onClick={handleFormat}
-            disabled={isLoading || !isValidJson}
-            className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] hover:bg-[rgb(var(--surface-hover))] rounded-lg transition-colors disabled:opacity-50"
-            title="Format JSON (Ctrl+Shift+F)"
-          >
-            <Wand2 className="h-4 w-4" />
-            Format
-          </button>
+            <button
+              onClick={handleFormat}
+              disabled={isLoading || !isValidJson}
+              className="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium text-[rgb(var(--muted))] transition-colors hover:bg-[rgb(var(--surface-hover))] hover:text-[rgb(var(--foreground))] disabled:opacity-50"
+              title="Format JSON (Ctrl+Shift+F)"
+            >
+              <Wand2 className="h-4 w-4" />
+              Format
+            </button>
 
-          <div className="flex-1" />
+            <button
+              onClick={handleInsertCustomServer}
+              disabled={isLoading || !isValidJson}
+              className="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium text-[rgb(var(--muted))] transition-colors hover:bg-[rgb(var(--surface-hover))] hover:text-[rgb(var(--foreground))] disabled:opacity-50"
+              title="Insert another unique custom server entry"
+            >
+              <Plus className="h-4 w-4" />
+              Insert Server
+            </button>
 
-          {!isValidJson && (
-            <span className="flex items-center gap-1.5 text-xs text-[rgb(var(--error))] px-2 font-medium">
-              <AlertTriangle className="h-3 w-3" />
-              {validationErrors.length > 0 ? 'Schema Error' : 'Invalid JSON'}
+            <div className="flex-1" />
+
+            {!isValidJson && (
+              <span className="flex items-center gap-1.5 px-2 text-xs font-medium text-[rgb(var(--error))]">
+                <AlertTriangle className="h-3 w-3" />
+                {validationErrors.length > 0 ? 'Schema Error' : 'Invalid JSON'}
+              </span>
+            )}
+
+            <span className="text-xs text-[rgb(var(--muted))]">
+              Ctrl+S save &middot; Ctrl+Shift+F format
             </span>
-          )}
-
-          <span className="text-xs text-[rgb(var(--muted))]">
-            Ctrl+S save &middot; Ctrl+Shift+F format
-          </span>
-        </div>
-
-        {/* Contribute / Request CTA — surfaces the registry templates so users
-            don't have to hand-roll a definition if one already exists upstream. */}
-        <div className="px-4 py-3 border-b border-[rgb(var(--border))] bg-[rgb(var(--surface-dim))]">
-          <RequestServerCTA />
-        </div>
-
-        {/* Editor Area */}
-        <div className="flex-1 relative min-h-0 bg-[#1e1e1e]">
-          {(isLoading || !editorReady) ? (
-            <div className="absolute inset-0 flex items-center justify-center">
-              <Loader2 className="h-8 w-8 animate-spin text-[rgb(var(--muted))]" />
-            </div>
-          ) : (
-            <Editor
-              height="100%"
-              defaultLanguage="json"
-              value={content}
-              theme="vs-dark"
-              onChange={handleContentChange}
-              beforeMount={handleEditorBeforeMount}
-              onMount={handleEditorMount}
-              onValidate={handleEditorValidation}
-              options={{
-                minimap: { enabled: false },
-                fontSize: 14,
-                fontFamily: "'Fira Code', 'Consolas', monospace",
-                lineNumbers: 'on',
-                scrollBeyondLastLine: false,
-                automaticLayout: true,
-                tabSize: 2,
-                wordWrap: 'on',
-                formatOnPaste: true,
-                formatOnType: true,
-                folding: true,
-                bracketPairColorization: { enabled: true },
-                guides: {
-                  bracketPairs: true,
-                  indentation: true,
-                },
-                padding: { top: 12, bottom: 12 },
-              }}
-              loading={
-                <div className="flex items-center justify-center h-full bg-[#1e1e1e]">
-                  <Loader2 className="h-8 w-8 animate-spin text-[rgb(var(--muted))]" />
-                </div>
-              }
-            />
-          )}
-        </div>
-
-        {/* Footer / Status Bar */}
-        {(error || validationErrors.length > 0) && (
-          <div className="p-2 bg-[rgb(var(--error))]/10 border-t border-[rgb(var(--error))]/20 text-[rgb(var(--error))] text-xs px-4 max-h-20 overflow-auto">
-            {error || validationErrors.slice(0, 3).join(' • ')}
-            {validationErrors.length > 3 && ` (+${validationErrors.length - 3} more)`}
           </div>
-        )}
+
+          {/* Contribute / Request CTA — surfaces the registry templates so users
+            don't have to hand-roll a definition if one already exists upstream. */}
+          <div className="border-b border-[rgb(var(--border))] bg-[rgb(var(--surface-dim))] px-4 py-3">
+            <RequestServerCTA />
+          </div>
+
+          {/* Editor Area */}
+          <div className="relative min-h-0 flex-1 bg-[#1e1e1e]">
+            {isLoading || !editorReady ? (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <Loader2 className="h-8 w-8 animate-spin text-[rgb(var(--muted))]" />
+              </div>
+            ) : (
+              <Editor
+                height="100%"
+                defaultLanguage="json"
+                value={content}
+                theme="vs-dark"
+                onChange={handleContentChange}
+                beforeMount={handleEditorBeforeMount}
+                onMount={handleEditorMount}
+                onValidate={handleEditorValidation}
+                options={{
+                  minimap: { enabled: false },
+                  fontSize: 14,
+                  fontFamily: "'Fira Code', 'Consolas', monospace",
+                  lineNumbers: 'on',
+                  scrollBeyondLastLine: false,
+                  automaticLayout: true,
+                  tabSize: 2,
+                  wordWrap: 'on',
+                  formatOnPaste: true,
+                  formatOnType: true,
+                  folding: true,
+                  bracketPairColorization: { enabled: true },
+                  guides: {
+                    bracketPairs: true,
+                    indentation: true,
+                  },
+                  padding: { top: 12, bottom: 12 },
+                }}
+                loading={
+                  <div className="flex h-full items-center justify-center bg-[#1e1e1e]">
+                    <Loader2 className="h-8 w-8 animate-spin text-[rgb(var(--muted))]" />
+                  </div>
+                }
+              />
+            )}
+          </div>
+
+          {/* Footer / Status Bar */}
+          {(error || validationErrors.length > 0) && (
+            <div className="max-h-20 overflow-auto border-t border-[rgb(var(--error))]/20 bg-[rgb(var(--error))]/10 p-2 px-4 text-xs text-[rgb(var(--error))]">
+              {error || validationErrors.slice(0, 3).join(' • ')}
+              {validationErrors.length > 3 && ` (+${validationErrors.length - 3} more)`}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
     </>
   );
 }

--- a/apps/desktop/src/features/servers/ServersPage.tsx
+++ b/apps/desktop/src/features/servers/ServersPage.tsx
@@ -1836,6 +1836,7 @@ export function ServersPage() {
         <ConfigEditorModal
           spaceId={editConfigSpace.id}
           spaceName={editConfigSpace.name}
+          insertNewServer
           onClose={() => setEditConfigSpace(null)}
           onSaved={() => {
             loadData(); // Reload servers after config save

--- a/crates/mcpmux-core/src/application/user_space_sync.rs
+++ b/crates/mcpmux-core/src/application/user_space_sync.rs
@@ -3,7 +3,7 @@
 //! Syncs servers from user space JSON configuration files into InstalledServer records.
 //! This enables a unified connection flow regardless of server source (Registry vs UserConfig).
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -74,6 +74,25 @@ impl UserSpaceSyncService {
 
         // 2. Convert to ServerDefinitions
         let definitions = config.to_server_definitions(space_id, file_path.to_path_buf());
+
+        // User-config keys are normalized into MCP-safe server IDs. Do not allow
+        // two entries to collapse to the same ID; that would make the sync loop
+        // update the same InstalledServer row and appear to overwrite the previous
+        // custom server.
+        let mut seen_ids: HashMap<String, String> = HashMap::new();
+        for definition in &definitions {
+            if let Some(first_name) =
+                seen_ids.insert(definition.id.clone(), definition.name.clone())
+            {
+                anyhow::bail!(
+                    "Multiple custom servers normalize to the same id '{}': '{}' and '{}'. Rename one mcpServers key to a distinct alphanumeric/hyphen/dot id.",
+                    definition.id,
+                    first_name,
+                    definition.name
+                );
+            }
+        }
+
         let file_server_ids: HashSet<String> = definitions.iter().map(|d| d.id.clone()).collect();
 
         debug!(

--- a/crates/mcpmux-core/src/application/user_space_sync.rs
+++ b/crates/mcpmux-core/src/application/user_space_sync.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result};
 use tracing::{debug, info};
 
 use crate::domain::config::UserSpaceConfig;
-use crate::domain::{InstallationSource, InstalledServer};
+use crate::domain::{InstallationSource, InstalledServer, ServerDefinition};
 use crate::repository::InstalledServerRepository;
 
 /// Result of a sync operation
@@ -48,6 +48,29 @@ impl UserSpaceSyncService {
         Self { installed_repo }
     }
 
+    /// Ensure no two user-config entries normalize to the same MCP server id.
+    ///
+    /// User-config keys are normalized into MCP-safe server ids; if two entries
+    /// collapse to the same id the sync loop would update the same
+    /// `InstalledServer` row and appear to overwrite the previous custom server.
+    /// Reject that up front with a clear error instead of silently dropping one.
+    fn ensure_unique_server_ids(definitions: &[ServerDefinition]) -> Result<()> {
+        let mut seen_ids: HashMap<String, String> = HashMap::new();
+        for definition in definitions {
+            if let Some(first_name) =
+                seen_ids.insert(definition.id.clone(), definition.name.clone())
+            {
+                anyhow::bail!(
+                    "Multiple custom servers normalize to the same id '{}': '{}' and '{}'. Rename one mcpServers key to a distinct alphanumeric/hyphen/dot id.",
+                    definition.id,
+                    first_name,
+                    definition.name
+                );
+            }
+        }
+        Ok(())
+    }
+
     /// Sync servers from a user space JSON file into InstalledServer records
     ///
     /// This performs a 3-way diff:
@@ -75,23 +98,10 @@ impl UserSpaceSyncService {
         // 2. Convert to ServerDefinitions
         let definitions = config.to_server_definitions(space_id, file_path.to_path_buf());
 
-        // User-config keys are normalized into MCP-safe server IDs. Do not allow
-        // two entries to collapse to the same ID; that would make the sync loop
-        // update the same InstalledServer row and appear to overwrite the previous
-        // custom server.
-        let mut seen_ids: HashMap<String, String> = HashMap::new();
-        for definition in &definitions {
-            if let Some(first_name) =
-                seen_ids.insert(definition.id.clone(), definition.name.clone())
-            {
-                anyhow::bail!(
-                    "Multiple custom servers normalize to the same id '{}': '{}' and '{}'. Rename one mcpServers key to a distinct alphanumeric/hyphen/dot id.",
-                    definition.id,
-                    first_name,
-                    definition.name
-                );
-            }
-        }
+        // User-config keys are normalized into MCP-safe server IDs; reject two
+        // entries that collapse to the same ID up front so the sync loop can't
+        // silently overwrite one custom server with another.
+        Self::ensure_unique_server_ids(&definitions)?;
 
         let file_server_ids: HashSet<String> = definitions.iter().map(|d| d.id.clone()).collect();
 
@@ -251,5 +261,40 @@ mod tests {
         result.removed.push("c".to_string());
 
         assert_eq!(result.total_changes(), 3);
+    }
+
+    fn definitions_from(json: &str) -> Vec<ServerDefinition> {
+        let config: UserSpaceConfig = serde_json::from_str(json).expect("valid config json");
+        config.to_server_definitions("space-1", std::path::PathBuf::from("test.json"))
+    }
+
+    #[test]
+    fn ensure_unique_server_ids_rejects_colliding_normalized_ids() {
+        // "My Server" and "my_server" both normalize to "myserver".
+        let definitions = definitions_from(
+            r#"{ "mcpServers": {
+                "My Server": { "command": "echo" },
+                "my_server": { "command": "echo" }
+            } }"#,
+        );
+
+        let err = UserSpaceSyncService::ensure_unique_server_ids(&definitions)
+            .expect_err("colliding normalized ids must be rejected");
+        assert!(
+            err.to_string().contains("myserver"),
+            "error should name the colliding id, got: {err}"
+        );
+    }
+
+    #[test]
+    fn ensure_unique_server_ids_accepts_distinct_ids() {
+        let definitions = definitions_from(
+            r#"{ "mcpServers": {
+                "alpha": { "command": "echo" },
+                "beta": { "command": "echo" }
+            } }"#,
+        );
+
+        assert!(UserSpaceSyncService::ensure_unique_server_ids(&definitions).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Fixes custom server editing flows so adding/saving custom servers does not appear stale or overwrite the previous entry.

What changes:

- The config editor can insert a unique custom server draft key, e.g. `custom-server`, `custom-server-2`, etc.
- Opening Add Custom Server inserts a new unique draft instead of forcing users to manually copy/paste blocks.
- Saving a space config now synchronously syncs the just-saved file into installed server records, rather than relying only on the debounced watcher.
- Detects collisions where different config keys normalize to the same server ID and returns a clear error instead of silently overwriting one entry.

## Testing

- `cargo check -p mcpmux-core -p mcpmux`
- `pnpm typecheck`
