### PR TITLE
ci: make desktop PR/E2E builds fork-safe (no signing secret required)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,10 +239,13 @@ jobs:
             tauri-cli-${{ runner.os }}-
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build
+      # PR build verification only: disable updater-artifact signing so the build
+      # needs no secrets. Fork PRs don't receive repository secrets, so requiring
+      # TAURI_SIGNING_PRIVATE_KEY here makes every fork PR fail. Real signed
+      # updater artifacts are produced by the release flow (build-tauri.yml /
+      # nightly.yml) on trusted refs, which is the only place the key belongs.
+      - run: pnpm --filter @mcpmux/desktop exec tauri build --config '{"bundle":{"createUpdaterArtifacts":false}}'
         env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           # Ad-hoc signing (no Apple Developer ID)
           APPLE_SIGNING_IDENTITY: '-'
 

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -97,20 +97,23 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # E2E only needs a runnable app binary, not signed updater artifacts.
+      # Drop the `updater` bundle and disable updater-artifact creation so the
+      # build requires no signing key — fork PRs don't receive repository
+      # secrets, so requiring the key here makes every fork PR fail. Signed
+      # updater artifacts are produced by the release flow on trusted refs.
       - name: Build app (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: pnpm --filter @mcpmux/desktop exec tauri build --bundles deb,rpm,updater
+        run: pnpm --filter @mcpmux/desktop exec tauri build --bundles deb,rpm --config '{"bundle":{"createUpdaterArtifacts":false}}'
         env:
           PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
       - name: Build app (Windows)
         if: matrix.os == 'windows-latest'
-        run: pnpm build
-        env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        # shell: bash so the inline --config JSON is passed verbatim; PowerShell's
+        # native-argument handling would mangle the embedded double quotes.
+        shell: bash
+        run: pnpm --filter @mcpmux/desktop exec tauri build --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
       # TODO(playwright-migration): desktop E2E has stale assertions from the IA
       # redesign and is being replaced (tauri-playwright spike). Non-blocking


### PR DESCRIPTION
## Problem

CI fails on PRs opened from **forks** (e.g. #191) even for trivial changes. Every secret-free check passes (`rust-check`, `ts-check`, `rust-test` ×3, `e2e-web`), but `build` and all `e2e-desktop` jobs go red.

**Root cause:** GitHub does not expose repository secrets to workflows triggered by `pull_request` from a fork. `tauri.conf.json` has `bundle.createUpdaterArtifacts: true` with an updater `pubkey`, so every `tauri build` tries to sign updater artifacts and requires `TAURI_SIGNING_PRIVATE_KEY`. On fork PRs that secret resolves to an empty string, so the build fails with *"a public key has been found, but no private key"* — taking down `build`, both `e2e-desktop` legs, and the downstream `e2e-report`.

## Fix

PR validation only needs a **runnable app binary**, not signed updater artifacts. The desktop E2E suite never consumes them: its update tests are either mocked in vitest (`tests/ts/lib/updates.test.ts`) or `test.skip`ped (`tests/e2e/specs/settings.spec.ts`), and at runtime the updater verifies the **remote** `latest.json` against the embedded `pubkey` — never the locally-built `.sig`. So disable updater-artifact creation for the PR/E2E builds:

- **`ci.yml` `build`** -> `tauri build --config '{"bundle":{"createUpdaterArtifacts":false}}'`; drop the now-unused signing env.
- **`e2e-desktop.yml` Linux** -> drop the `updater` bundle target and add the same `--config` override.
- **`e2e-desktop.yml` Windows** -> same override, run under `shell: bash` so PowerShell's native-argument handling doesn't mangle the inline JSON quotes.

No production secret is exposed to fork code. **Real signed updater artifacts are still produced by the release flow** (`build-tauri.yml` / `nightly.yml`) on trusted refs, which remains the only place `TAURI_SIGNING_PRIVATE_KEY` is used.

## Out of scope / follow-ups

- Optional hardening: flip `createUpdaterArtifacts` to `false` as the **default** in `tauri.conf.json` and enable it only on the release path — enforces "secrets only on the release path" at the config level and removes the per-job override. Left out here to keep the release pipeline untouched.
- After this merges, **rebase #191 onto `main`** so it picks up the fixed workflows and re-runs green.

## Testing

- Both workflow YAMLs parse (`yaml.safe_load`).
- Pre-commit suite passes (`cargo fmt` + `clippy` + ESLint + `tsc`).
- CI on this PR exercises the new build commands on Linux/Windows/macOS.
