### PR TITLE
feat: generalized client→Space/FeatureSet mappings + lock-confine (P2/3)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/oauth.rs
+++ b/apps/desktop/src-tauri/src/commands/oauth.rs
@@ -37,6 +37,7 @@ use tracing::{debug, error, info, warn};
 use url::Url;
 
 use super::gateway::GatewayAppState;
+use crate::state::AppState;
 
 // ============================================================================
 // Deep Link Handling
@@ -979,6 +980,7 @@ fn generate_api_key() -> (String, String, String) {
 #[tauri::command]
 pub async fn register_api_key_client(
     gateway_state: State<'_, Arc<RwLock<GatewayAppState>>>,
+    app: State<'_, AppState>,
     name: String,
     locked_space_id: Option<String>,
 ) -> Result<RegisteredApiKeyClient, String> {
@@ -1042,6 +1044,18 @@ pub async fn register_api_key_client(
         trimmed, client_id
     );
 
+    // Best-effort: auto-create a clientId-keyed mapping → the (locked or
+    // default) Space's Starter, so the client routes sensibly out of the box
+    // and the mapping is visible + editable in the Mapping tab. A failure here
+    // must not undo the registration — without an explicit mapping the resolver
+    // still falls back to the default Starter.
+    if let Err(e) = auto_map_api_key_client(&app, &client_id, locked_space_id.as_deref()).await {
+        warn!(
+            "[OAuth] auto-map for {} failed (non-fatal): {}",
+            client_id, e
+        );
+    }
+
     Ok(RegisteredApiKeyClient {
         client_id,
         client_name: trimmed.to_string(),
@@ -1049,6 +1063,40 @@ pub async fn register_api_key_client(
         api_key: plaintext,
         key_prefix,
     })
+}
+
+/// Auto-create a clientId-keyed `id` mapping pointing at the (locked or
+/// default) Space's Starter FeatureSet, so a freshly-registered API-key client
+/// routes somewhere sensible by default and the operator can retarget it from
+/// the Mapping tab.
+async fn auto_map_api_key_client(
+    app: &AppState,
+    client_id: &str,
+    locked_space_id: Option<&str>,
+) -> Result<(), String> {
+    let space_id = match locked_space_id {
+        Some(s) => uuid::Uuid::parse_str(s).map_err(|e| e.to_string())?,
+        None => {
+            app.space_service
+                .get_default()
+                .await
+                .map_err(|e| e.to_string())?
+                .ok_or("no default Space configured")?
+                .id
+        }
+    };
+    let starter = app
+        .feature_set_repository
+        .get_starter_for_space(&space_id.to_string())
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or("Space has no Starter FeatureSet")?;
+    let binding =
+        mcpmux_core::WorkspaceBinding::new_id(client_id.to_string(), space_id, vec![starter.id]);
+    app.workspace_binding_repository
+        .create(&binding)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Issue an additional API key for an existing client (rotation). Returns the

--- a/apps/desktop/src-tauri/src/commands/oauth.rs
+++ b/apps/desktop/src-tauri/src/commands/oauth.rs
@@ -901,6 +901,7 @@ pub async fn update_oauth_client(
 #[tauri::command]
 pub async fn delete_oauth_client(
     gateway_state: State<'_, Arc<RwLock<GatewayAppState>>>,
+    app: State<'_, AppState>,
     client_id: String,
 ) -> Result<(), String> {
     let app_state = gateway_state.read().await;
@@ -921,6 +922,23 @@ pub async fn delete_oauth_client(
         .map_err(|e| format!("Failed to delete client: {}", e))?;
 
     info!("[OAuth] Deleted client: {}", client_id);
+
+    // Best-effort: remove the auto-mapped clientId id-binding so a deleted
+    // client doesn't leave an orphan "<client_id> → Starter" mapping behind in
+    // the Mapping tab. Only API-key clients have such a binding; for DCR
+    // clients this is a no-op.
+    if let Ok(Some(b)) = app
+        .workspace_binding_repository
+        .find_by_id_key(&client_id)
+        .await
+    {
+        if let Err(e) = app.workspace_binding_repository.delete(&b.id).await {
+            warn!(
+                "[OAuth] failed to remove clientId mapping for {}: {}",
+                client_id, e
+            );
+        }
+    }
 
     // Emit domain event
     state.emit_domain_event(mcpmux_core::DomainEvent::ClientDeleted { client_id });

--- a/apps/desktop/src-tauri/src/commands/oauth.rs
+++ b/apps/desktop/src-tauri/src/commands/oauth.rs
@@ -943,6 +943,7 @@ pub async fn delete_oauth_client(
 pub struct RegisteredApiKeyClient {
     pub client_id: String,
     pub client_name: String,
+    pub locked_space_id: Option<String>,
     pub api_key: String,
     pub key_prefix: String,
 }
@@ -973,12 +974,13 @@ fn generate_api_key() -> (String, String, String) {
     (key_id, plaintext, key_prefix)
 }
 
-/// Register a new pre-approved client authenticated by an API key. The returned
-/// `api_key` is shown once and never stored.
+/// Register a new pre-approved client authenticated by an API key, optionally
+/// locked to a Space. The returned `api_key` is shown once and never stored.
 #[tauri::command]
 pub async fn register_api_key_client(
     gateway_state: State<'_, Arc<RwLock<GatewayAppState>>>,
     name: String,
+    locked_space_id: Option<String>,
 ) -> Result<RegisteredApiKeyClient, String> {
     let app_state = gateway_state.read().await;
     let Some(ref gw_state) = app_state.gateway_state else {
@@ -1024,6 +1026,12 @@ pub async fn register_api_key_client(
         .await
         .map_err(|e| format!("Failed to create client: {}", e))?;
 
+    if let Some(ref space) = locked_space_id {
+        repo.set_locked_space(&client_id, Some(space))
+            .await
+            .map_err(|e| format!("Failed to lock client to space: {}", e))?;
+    }
+
     let (key_id, plaintext, key_prefix) = generate_api_key();
     repo.create_api_key(&key_id, &client_id, &plaintext, &key_prefix, None, None)
         .await
@@ -1037,6 +1045,7 @@ pub async fn register_api_key_client(
     Ok(RegisteredApiKeyClient {
         client_id,
         client_name: trimmed.to_string(),
+        locked_space_id,
         api_key: plaintext,
         key_prefix,
     })
@@ -1079,9 +1088,15 @@ pub async fn create_client_api_key(
     .await
     .map_err(|e| format!("Failed to create API key: {}", e))?;
 
+    let locked_space_id = repo
+        .get_locked_space(&client_id)
+        .await
+        .map_err(|e| format!("Failed to read client: {}", e))?;
+
     Ok(RegisteredApiKeyClient {
         client_id,
         client_name: client.client_name,
+        locked_space_id,
         api_key: plaintext,
         key_prefix,
     })

--- a/apps/desktop/src-tauri/src/commands/workspace_binding.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace_binding.rs
@@ -8,8 +8,8 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use mcpmux_core::{
-    validate_workspace_root as validate_root, DomainEvent, FeatureSet, FeatureSetType, MemberMode,
-    MemberType, ServerFeature, WorkspaceBinding, WorkspaceRootValidation,
+    validate_workspace_root as validate_root, BindingType, DomainEvent, FeatureSet, FeatureSetType,
+    MemberMode, MemberType, ServerFeature, WorkspaceBinding, WorkspaceRootValidation,
 };
 use serde::{Deserialize, Serialize};
 use tauri::State;
@@ -54,6 +54,8 @@ async fn emit_binding_changed(
 pub struct WorkspaceBindingDto {
     pub id: String,
     pub workspace_root: String,
+    /// `path` (folder, normalized) or `id` (arbitrary exact-match key).
+    pub binding_type: String,
     pub space_id: String,
     pub feature_set_ids: Vec<String>,
     pub created_at: String,
@@ -65,6 +67,7 @@ impl From<WorkspaceBinding> for WorkspaceBindingDto {
         Self {
             id: b.id.to_string(),
             workspace_root: b.workspace_root,
+            binding_type: b.binding_type.as_str().to_string(),
             space_id: b.space_id.to_string(),
             feature_set_ids: b.feature_set_ids,
             created_at: b.created_at.to_rfc3339(),
@@ -83,6 +86,10 @@ pub struct WorkspaceBindingInput {
     pub workspace_root: String,
     pub space_id: String,
     pub feature_set_ids: Vec<String>,
+    /// `path` (default — folder, normalized + validated) or `id` (arbitrary
+    /// exact-match key, taken verbatim). Optional for backward compatibility.
+    #[serde(default)]
+    pub binding_type: Option<String>,
 }
 
 fn parse_space_id(input: &WorkspaceBindingInput) -> Result<Uuid, String> {
@@ -229,6 +236,26 @@ fn normalize_and_validate(raw: &str) -> Result<String, String> {
     }
 }
 
+/// Resolve the storage key + type from the input. `path` bindings are
+/// normalized + validated (rejecting relative paths, filesystem roots, …);
+/// `id` bindings take the raw string verbatim (any non-empty label a headless
+/// client sends in `X-Mcpmux-Workspace`, e.g. a client id or machine name).
+fn resolve_key_and_type(input: &WorkspaceBindingInput) -> Result<(String, BindingType), String> {
+    match input.binding_type.as_deref() {
+        Some("id") => {
+            let key = input.workspace_root.trim();
+            if key.is_empty() {
+                return Err("Mapping id cannot be empty".into());
+            }
+            Ok((key.to_string(), BindingType::Id))
+        }
+        _ => Ok((
+            normalize_and_validate(&input.workspace_root)?,
+            BindingType::Path,
+        )),
+    }
+}
+
 /// Create a binding. Path is normalized + validated server-side so the UI
 /// can pass raw input (Windows paths, file:// URIs, trailing slashes).
 #[tauri::command]
@@ -239,9 +266,9 @@ pub async fn create_workspace_binding(
 ) -> Result<WorkspaceBindingDto, String> {
     let space_id = parse_space_id(&input)?;
     let feature_set_ids = validate_fs_list(&input)?;
-    let normalized = normalize_and_validate(&input.workspace_root)?;
+    let (key, binding_type) = resolve_key_and_type(&input)?;
 
-    // Reject a duplicate folder up front with a readable message. The schema
+    // Reject a duplicate key up front with a readable message. The schema
     // already enforces `UNIQUE(workspace_root)`, but that surfaces an opaque
     // SQLite constraint error — this gives the UI something a user can act on.
     let existing = state
@@ -249,13 +276,16 @@ pub async fn create_workspace_binding(
         .list()
         .await
         .map_err(|e| e.to_string())?;
-    if existing.iter().any(|b| b.workspace_root == normalized) {
+    if existing.iter().any(|b| b.workspace_root == key) {
         return Err(format!(
-            "A mapping already exists for {normalized}. Edit the existing mapping instead of adding a second one."
+            "A mapping already exists for {key}. Edit the existing mapping instead of adding a second one."
         ));
     }
 
-    let binding = WorkspaceBinding::new_multi(normalized.clone(), space_id, feature_set_ids);
+    let binding = match binding_type {
+        BindingType::Id => WorkspaceBinding::new_id(key.clone(), space_id, feature_set_ids),
+        BindingType::Path => WorkspaceBinding::new_multi(key.clone(), space_id, feature_set_ids),
+    };
 
     state
         .workspace_binding_repository
@@ -292,9 +322,9 @@ pub async fn update_workspace_binding(
     let id_uuid = Uuid::parse_str(&id).map_err(|e| e.to_string())?;
     let space_id = parse_space_id(&input)?;
     let feature_set_ids = validate_fs_list(&input)?;
-    let normalized = normalize_and_validate(&input.workspace_root)?;
+    let (key, binding_type) = resolve_key_and_type(&input)?;
 
-    // If the edit moved the folder onto a path another mapping already owns,
+    // If the edit moved the mapping onto a key another mapping already owns,
     // reject with a readable message rather than tripping the DB UNIQUE
     // constraint. Exclude this binding's own row.
     let all = state
@@ -304,10 +334,10 @@ pub async fn update_workspace_binding(
         .map_err(|e| e.to_string())?;
     if all
         .iter()
-        .any(|b| b.id != id_uuid && b.workspace_root == normalized)
+        .any(|b| b.id != id_uuid && b.workspace_root == key)
     {
         return Err(format!(
-            "Another mapping already uses {normalized}. Pick a different folder."
+            "Another mapping already uses {key}. Pick a different key."
         ));
     }
 
@@ -321,7 +351,8 @@ pub async fn update_workspace_binding(
 
     let updated = WorkspaceBinding {
         id: existing.id,
-        workspace_root: normalized,
+        workspace_root: key,
+        binding_type,
         space_id,
         feature_set_ids,
         created_at: existing.created_at,

--- a/apps/desktop/src/features/clients/RegisterApiKeyClientModal.tsx
+++ b/apps/desktop/src/features/clients/RegisterApiKeyClientModal.tsx
@@ -10,10 +10,11 @@
  * never display it again — if lost, revoke it and issue a new one.
  */
 
-import { useState } from 'react';
-import { AlertTriangle, Check, Copy, KeyRound, Loader2, ShieldCheck, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { AlertTriangle, Check, Copy, KeyRound, Loader2, Lock, ShieldCheck, X } from 'lucide-react';
 import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from '@mcpmux/ui';
 import { registerApiKeyClient, type RegisteredApiKeyClient } from '@/lib/api/gateway';
+import { listSpaces, type Space } from '@/lib/api/spaces';
 
 interface RegisterApiKeyClientModalProps {
   onClose: () => void;
@@ -26,10 +27,22 @@ export function RegisterApiKeyClientModal({
   onRegistered,
 }: RegisterApiKeyClientModalProps) {
   const [name, setName] = useState('');
+  const [lockedSpaceId, setLockedSpaceId] = useState('');
+  const [spaces, setSpaces] = useState<Space[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<RegisteredApiKeyClient | null>(null);
   const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    listSpaces()
+      .then(setSpaces)
+      .catch(() => setSpaces([]));
+  }, []);
+
+  const lockedSpaceName = result?.lockedSpaceId
+    ? (spaces.find((s) => s.id === result.lockedSpaceId)?.name ?? 'a Space')
+    : null;
 
   const handleGenerate = async () => {
     const trimmed = name.trim();
@@ -40,7 +53,7 @@ export function RegisterApiKeyClientModal({
     setIsSubmitting(true);
     setError(null);
     try {
-      const client = await registerApiKeyClient(trimmed);
+      const client = await registerApiKeyClient(trimmed, lockedSpaceId || null);
       setResult(client);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -130,6 +143,13 @@ export function RegisterApiKeyClientModal({
                 <code className="block break-all font-mono text-xs text-[rgb(var(--text))]">
                   Authorization: Bearer {result.keyPrefix}…
                 </code>
+                {lockedSpaceName && (
+                  <p className="mt-2 flex items-center gap-1.5 text-xs text-[rgb(var(--muted))]">
+                    <Lock className="h-3.5 w-3.5" />
+                    Locked to <span className="font-medium">{lockedSpaceName}</span> — this key can
+                    only ever reach that Space.
+                  </p>
+                )}
               </div>
 
               <div className="flex justify-end">
@@ -157,6 +177,30 @@ export function RegisterApiKeyClientModal({
                   placeholder="e.g. CI runner, my-laptop, prod-bot"
                   className="w-full rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3.5 py-2.5 text-sm transition-all focus:border-[rgb(var(--accent))] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent))]/40"
                 />
+              </div>
+
+              <div>
+                <label htmlFor="api-key-lock-space" className="mb-1.5 block text-sm font-medium">
+                  Lock to a Space <span className="text-[rgb(var(--muted))]">(optional)</span>
+                </label>
+                <select
+                  id="api-key-lock-space"
+                  data-testid="register-api-key-lock-space"
+                  value={lockedSpaceId}
+                  onChange={(e) => setLockedSpaceId(e.target.value)}
+                  className="w-full rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3.5 py-2.5 text-sm transition-all focus:border-[rgb(var(--accent))] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--accent))]/40"
+                >
+                  <option value="">No lock — route by mapping (any Space)</option>
+                  {spaces.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </select>
+                <p className="mt-1.5 text-xs text-[rgb(var(--muted))]">
+                  Locking confines this client to one Space — a leaked key can never reach the
+                  others. Leave unlocked to route it later from the Workspaces tab.
+                </p>
               </div>
 
               <div className="flex items-start gap-3 rounded-xl border border-[rgb(var(--border-subtle))] bg-[rgb(var(--surface))] p-3.5">

--- a/apps/desktop/src/features/home/HomePage.tsx
+++ b/apps/desktop/src/features/home/HomePage.tsx
@@ -163,8 +163,9 @@ function GetStartedStrip() {
 
 /**
  * Per-folder setup entry point. The ConnectionCard above connects an app to
- * the gateway globally; this routes into the Workspaces walkthrough to map a
- * specific project and write its per-folder config.
+ * the gateway globally; this routes into the Mapping walkthrough (the create
+ * wizard, in folder mode) to map a specific project and write its per-folder
+ * config.
  */
 function SetUpFolderCard() {
   const navigateTo = useNavigateTo();
@@ -179,7 +180,7 @@ function SetUpFolderCard() {
       data-testid="home-setup-folder"
       className="group flex w-full items-center gap-3 rounded-xl border border-[rgb(var(--border-subtle))] bg-[rgb(var(--card))] p-4 text-left shadow transition-all duration-200 hover:-translate-y-0.5 hover:border-[rgb(var(--border))] hover:shadow-md"
     >
-      <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-[rgb(var(--primary))]/12 text-[rgb(var(--primary))]">
+      <span className="bg-[rgb(var(--primary))]/12 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg text-[rgb(var(--primary))]">
         <FolderPlus className="h-5 w-5" />
       </span>
       <span className="min-w-0 flex-1">
@@ -275,7 +276,7 @@ export function HomePage() {
           pending-approval nudge. */}
       <ConnectionCard />
 
-      {/* Per-folder setup — opens the Workspaces walkthrough. */}
+      {/* Per-folder setup — opens the Mapping walkthrough (folder mode). */}
       <SetUpFolderCard />
 
       {/* Stat tiles — each is a shortcut into the page that manages it. */}

--- a/apps/desktop/src/features/workspaces/WorkspaceSetupWizard.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspaceSetupWizard.tsx
@@ -5,6 +5,7 @@ import {
   ArrowLeft,
   ArrowRight,
   Check,
+  Copy,
   FolderOpen,
   FolderSearch,
   Layers,
@@ -53,6 +54,11 @@ export function WorkspaceSetupWizard({
   onError: (msg: string) => void;
 }) {
   const [step, setStep] = useState<1 | 2 | 3>(1);
+  // A mapping is keyed by a folder PATH (the default) or an arbitrary ID/label
+  // (a client id, machine name, … — for headless/remote clients). `folder`
+  // holds whichever value the user enters.
+  const [bindingType, setBindingType] = useState<'path' | 'id'>('path');
+  const isId = bindingType === 'id';
   const [folder, setFolder] = useState('');
   const [validating, setValidating] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -127,6 +133,7 @@ export function WorkspaceSetupWizard({
         workspace_root: folder,
         space_id: spaceId,
         feature_set_ids: Array.from(fsIds),
+        binding_type: bindingType,
       });
       // The parent transitions to the new mapping's inspector (which shows its
       // effective features) — don't close here, or that view would be lost.
@@ -136,11 +143,13 @@ export function WorkspaceSetupWizard({
     }
   };
 
-  const TITLES = ['Choose a folder', 'Connect your apps', 'Choose its tools'] as const;
+  const TITLES = isId
+    ? (['Choose an id', 'How clients connect', 'Choose its tools'] as const)
+    : (['Choose a folder', 'Connect your apps', 'Choose its tools'] as const);
 
   return (
     <div
-      className="fixed right-0 top-0 bottom-0 z-50 flex w-full min-w-[420px] max-w-[480px] flex-col border-l border-[rgb(var(--border))] bg-[rgb(var(--surface))] shadow-2xl animate-in slide-in-from-right duration-300"
+      className="animate-in slide-in-from-right fixed bottom-0 right-0 top-0 z-50 flex w-full min-w-[420px] max-w-[480px] flex-col border-l border-[rgb(var(--border))] bg-[rgb(var(--surface))] shadow-2xl duration-300"
       data-testid="workspace-setup-wizard"
     >
       {/* Header + progress */}
@@ -148,7 +157,7 @@ export function WorkspaceSetupWizard({
         <div className="flex items-start justify-between">
           <div className="min-w-0">
             <div className="text-xs font-medium uppercase tracking-wider text-[rgb(var(--muted))]">
-              Set up a folder · Step {step} of 3
+              {isId ? 'Set up an ID mapping' : 'Set up a folder'} · Step {step} of 3
             </div>
             <h2 className="mt-0.5 text-lg font-bold">{TITLES[step - 1]}</h2>
           </div>
@@ -175,80 +184,154 @@ export function WorkspaceSetupWizard({
       <div className="flex-1 overflow-y-auto p-6">
         {step === 1 && (
           <div className="space-y-4" data-testid="wizard-step-folder">
-            <p className="text-sm text-[rgb(var(--muted))]">
-              Which project folder do you want to map? Pick one, or choose a folder an app already
-              opened.
-            </p>
-            <Button variant="primary" size="sm" onClick={pickFolder} disabled={validating}>
-              {validating ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <FolderOpen className="mr-2 h-4 w-4" />
-              )}
-              Choose folder…
-            </Button>
+            {/* Folder vs ID — a folder routes editors by the path they open; an
+                id routes a headless/remote client by an exact label it sends. */}
+            <div className="flex gap-1 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-1">
+              {(['path', 'id'] as const).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setBindingType(t)}
+                  className={[
+                    'flex-1 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+                    bindingType === t
+                      ? 'bg-primary-500 text-white'
+                      : 'text-[rgb(var(--muted))] hover:bg-[rgb(var(--surface-hover))]',
+                  ].join(' ')}
+                  data-testid={`wizard-type-${t}`}
+                >
+                  {t === 'path' ? 'Folder' : 'ID / label'}
+                </button>
+              ))}
+            </div>
 
-            {folder && (
-              <div
-                className={`flex items-center gap-2 rounded-lg border px-3 py-2 ${
-                  alreadyMapped
-                    ? 'border-amber-300 bg-amber-50 dark:border-amber-800/60 dark:bg-amber-900/20'
-                    : 'border-[rgb(var(--border))] bg-[rgb(var(--background))]'
-                }`}
-              >
-                {alreadyMapped ? (
-                  <AlertCircle className="h-4 w-4 flex-shrink-0 text-amber-600" />
-                ) : (
-                  <Check className="h-4 w-4 flex-shrink-0 text-green-600" />
+            {isId ? (
+              <>
+                <p className="text-sm text-[rgb(var(--muted))]">
+                  Enter an id or label — a client id, machine name, or any string. A headless or
+                  remote client that sends this exact value in the{' '}
+                  <code className="font-mono text-xs">X-Mcpmux-Workspace</code> header gets the
+                  tools you choose next.
+                </p>
+                <input
+                  type="text"
+                  value={folder}
+                  onChange={(e) => setFolder(e.target.value)}
+                  placeholder="e.g. a client id or machine name"
+                  className="focus:ring-primary-500 w-full rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2"
+                  data-testid="wizard-id-input"
+                />
+                {alreadyMapped && (
+                  <p
+                    className="text-xs text-amber-700 dark:text-amber-400"
+                    data-testid="wizard-folder-mapped-error"
+                  >
+                    That id is already mapped — edit it from the Mapping list instead.
+                  </p>
                 )}
-                <span className="truncate font-mono text-xs" title={folder}>
-                  {folder}
-                </span>
-              </div>
-            )}
-            {alreadyMapped && (
-              <p
-                className="text-xs text-amber-700 dark:text-amber-400"
-                data-testid="wizard-folder-mapped-error"
-              >
-                This folder is already mapped — edit it from the Workspaces list instead.
-              </p>
-            )}
+              </>
+            ) : (
+              <>
+                <p className="text-sm text-[rgb(var(--muted))]">
+                  Which project folder do you want to map? Pick one, or choose a folder an app
+                  already opened.
+                </p>
+                <Button variant="primary" size="sm" onClick={pickFolder} disabled={validating}>
+                  {validating ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <FolderOpen className="mr-2 h-4 w-4" />
+                  )}
+                  Choose folder…
+                </Button>
 
-            {unmappedRoots.length > 0 && (
-              <div>
-                <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-[rgb(var(--muted))]">
-                  <FolderSearch className="h-3.5 w-3.5" />
-                  Detected workspaces
-                </div>
-                <div className="overflow-hidden rounded-lg border border-[rgb(var(--border))]">
-                  {unmappedRoots.slice(0, 6).map((r, i) => (
-                    <button
-                      key={r}
-                      type="button"
-                      onClick={() => setFolder(r)}
-                      className={`flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-[rgb(var(--surface-hover))] ${
-                        i > 0 ? 'border-t border-[rgb(var(--border-subtle))]' : ''
-                      } ${folder === r ? 'bg-primary-500/5' : ''}`}
-                    >
-                      <FolderOpen className="h-4 w-4 flex-shrink-0 text-[rgb(var(--muted))]" />
-                      <span className="truncate font-mono text-xs" title={r}>
-                        {r}
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              </div>
+                {folder && (
+                  <div
+                    className={`flex items-center gap-2 rounded-lg border px-3 py-2 ${
+                      alreadyMapped
+                        ? 'border-amber-300 bg-amber-50 dark:border-amber-800/60 dark:bg-amber-900/20'
+                        : 'border-[rgb(var(--border))] bg-[rgb(var(--background))]'
+                    }`}
+                  >
+                    {alreadyMapped ? (
+                      <AlertCircle className="h-4 w-4 flex-shrink-0 text-amber-600" />
+                    ) : (
+                      <Check className="h-4 w-4 flex-shrink-0 text-green-600" />
+                    )}
+                    <span className="truncate font-mono text-xs" title={folder}>
+                      {folder}
+                    </span>
+                  </div>
+                )}
+                {alreadyMapped && (
+                  <p
+                    className="text-xs text-amber-700 dark:text-amber-400"
+                    data-testid="wizard-folder-mapped-error"
+                  >
+                    This folder is already mapped — edit it from the Workspaces list instead.
+                  </p>
+                )}
+
+                {unmappedRoots.length > 0 && (
+                  <div>
+                    <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-[rgb(var(--muted))]">
+                      <FolderSearch className="h-3.5 w-3.5" />
+                      Detected workspaces
+                    </div>
+                    <div className="overflow-hidden rounded-lg border border-[rgb(var(--border))]">
+                      {unmappedRoots.slice(0, 6).map((r, i) => (
+                        <button
+                          key={r}
+                          type="button"
+                          onClick={() => setFolder(r)}
+                          className={`flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-[rgb(var(--surface-hover))] ${
+                            i > 0 ? 'border-t border-[rgb(var(--border-subtle))]' : ''
+                          } ${folder === r ? 'bg-primary-500/5' : ''}`}
+                        >
+                          <FolderOpen className="h-4 w-4 flex-shrink-0 text-[rgb(var(--muted))]" />
+                          <span className="truncate font-mono text-xs" title={r}>
+                            {r}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </>
             )}
           </div>
         )}
 
         {step === 2 && (
           <div className="space-y-3" data-testid="wizard-step-apps">
-            <WorkspaceInstallPanel workspaceRoot={folder} />
-            <p className="text-center text-xs text-[rgb(var(--muted))]">
-              Optional — you can connect apps later from this folder&apos;s mapping.
-            </p>
+            {isId ? (
+              <div className="space-y-3">
+                <p className="text-sm text-[rgb(var(--muted))]">
+                  A headless or remote client routes here by sending this id in the{' '}
+                  <code className="font-mono text-xs">X-Mcpmux-Workspace</code> header. There&apos;s
+                  no folder to auto-write app config for — copy the value into your client.
+                </p>
+                <div className="flex items-stretch gap-2">
+                  <code className="flex-1 select-all break-all rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 font-mono text-xs">
+                    {folder || '—'}
+                  </code>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => void navigator.clipboard.writeText(folder).catch(() => {})}
+                  >
+                    <Copy className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <>
+                <WorkspaceInstallPanel workspaceRoot={folder} />
+                <p className="text-center text-xs text-[rgb(var(--muted))]">
+                  Optional — you can connect apps later from this folder&apos;s mapping.
+                </p>
+              </>
+            )}
           </div>
         )}
 
@@ -299,9 +382,9 @@ export function WorkspaceSetupWizard({
                         type="checkbox"
                         checked={fsIds.has(fs.id)}
                         onChange={() => toggleFs(fs.id)}
-                        className="h-4 w-4 flex-shrink-0 accent-primary-500"
+                        className="accent-primary-500 h-4 w-4 flex-shrink-0"
                       />
-                      <Layers className="h-4 w-4 flex-shrink-0 text-primary-500" />
+                      <Layers className="text-primary-500 h-4 w-4 flex-shrink-0" />
                       <span className="min-w-0 flex-1 truncate text-sm font-medium">{fs.name}</span>
                       {isStarterFeatureSet(fs) && (
                         <span className="flex-shrink-0 rounded-full bg-[rgb(var(--surface))] px-1.5 text-[10px] font-semibold uppercase tracking-wider text-[rgb(var(--muted))]">
@@ -354,7 +437,11 @@ export function WorkspaceSetupWizard({
             disabled={saving || fsIds.size === 0 || !folder}
             data-testid="wizard-finish"
           >
-            {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Wrench className="mr-1.5 h-4 w-4" />}
+            {saving ? (
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+            ) : (
+              <Wrench className="mr-1.5 h-4 w-4" />
+            )}
             Finish
           </Button>
         )}

--- a/apps/desktop/src/features/workspaces/WorkspacesPage.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspacesPage.tsx
@@ -1610,7 +1610,10 @@ function BindingForm({
   const [fsIds, setFsIds] = useState<string[]>(initial?.feature_set_ids ?? []);
   // A mapping is keyed by a folder path OR an arbitrary id/label. The type is
   // chosen at create time and fixed thereafter (an id never becomes a folder).
-  const [bindingType, setBindingType] = useState<'path' | 'id'>(initial?.binding_type ?? 'path');
+  // Mapping type is chosen in the create wizard and fixed thereafter; here
+  // (edit / create-from-live) we only read it so an id mapping isn't
+  // re-validated as a filesystem path.
+  const bindingType = initial?.binding_type ?? 'path';
   const isId = bindingType === 'id';
   const [fsSearch, setFsSearch] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -1831,27 +1834,6 @@ function BindingForm({
           ? 'Enter an id or label (a client id, machine name, or any string), then choose the tools it gets. A headless or remote client that sends this exact value in the X-Mcpmux-Workspace header receives exactly those tools.'
           : 'Pick a folder, then choose the tools it should get. Whenever you open that folder in a connected app — Cursor, VS Code, Claude — McpMux hands it exactly the tools you choose here, and nothing else.'}
       </div>
-
-      {mode === 'create' && (
-        <div className="flex gap-1 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-1">
-          {(['path', 'id'] as const).map((t) => (
-            <button
-              key={t}
-              type="button"
-              onClick={() => setBindingType(t)}
-              className={[
-                'flex-1 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
-                bindingType === t
-                  ? 'bg-primary-500 text-white'
-                  : 'text-[rgb(var(--muted))] hover:bg-[rgb(var(--surface-hover))]',
-              ].join(' ')}
-              data-testid={`workspace-binding-type-${t}`}
-            >
-              {t === 'path' ? 'Folder' : 'ID / label'}
-            </button>
-          ))}
-        </div>
-      )}
 
       <FormField label={isId ? 'Mapping ID / label' : 'Workspace folder'}>
         <div className="flex gap-2">

--- a/apps/desktop/src/features/workspaces/WorkspacesPage.tsx
+++ b/apps/desktop/src/features/workspaces/WorkspacesPage.tsx
@@ -23,14 +23,7 @@ import {
   Wrench,
   X,
 } from 'lucide-react';
-import {
-  Button,
-  Card,
-  CardContent,
-  useToast,
-  ToastContainer,
-  useConfirm,
-} from '@mcpmux/ui';
+import { Button, Card, CardContent, useToast, ToastContainer, useConfirm } from '@mcpmux/ui';
 import {
   clearUnmappedReportedRoots,
   createWorkspaceBinding,
@@ -45,11 +38,7 @@ import {
   type WorkspaceBindingInput,
   type WorkspaceEffectiveFeatures,
 } from '@/lib/api/workspaceBindings';
-import {
-  isStarterFeatureSet,
-  listFeatureSets,
-  type FeatureSet,
-} from '@/lib/api/featureSets';
+import { isStarterFeatureSet, listFeatureSets, type FeatureSet } from '@/lib/api/featureSets';
 import { WorkspaceInstallPanel } from './WorkspaceInstallPanel';
 import { WorkspaceSetupWizard } from './WorkspaceSetupWizard';
 import { useSpaces, usePendingWorkspaceNew, useSetPendingWorkspaceNew } from '@/stores';
@@ -220,11 +209,9 @@ export function WorkspacesPage() {
       if (filter === 'mapped' && !e.binding) return false;
       if (filter === 'unmapped' && e.kind !== 'unmapped-live') return false;
       if (!q) return true;
-      const spaceName = e.binding ? spaceById.get(e.binding.space_id)?.name ?? '' : '';
+      const spaceName = e.binding ? (spaceById.get(e.binding.space_id)?.name ?? '') : '';
       const fsNames = e.binding
-        ? e.binding.feature_set_ids
-            .map((id) => fsById.get(id)?.name ?? '')
-            .join(' ')
+        ? e.binding.feature_set_ids.map((id) => fsById.get(id)?.name ?? '').join(' ')
         : '';
       return (
         e.root.toLowerCase().includes(q) ||
@@ -247,7 +234,7 @@ export function WorkspacesPage() {
   }, [entries]);
 
   const selectedEntry: Entry | null =
-    selected?.mode === 'entry' ? entries.find((e) => e.id === selected.id) ?? null : null;
+    selected?.mode === 'entry' ? (entries.find((e) => e.id === selected.id) ?? null) : null;
   const selectedIsNew = selected?.mode === 'new';
   const panelOpen = selected !== null;
 
@@ -311,32 +298,27 @@ export function WorkspacesPage() {
         cleared > 0 ? "You'll be asked to map them again next time." : undefined
       );
     } catch (e) {
-      showError(
-        'Could not clear unmapped folders',
-        e instanceof Error ? e.message : String(e)
-      );
+      showError('Could not clear unmapped folders', e instanceof Error ? e.message : String(e));
     }
   };
 
   return (
-    <div className="h-full flex flex-col relative" data-testid="workspaces-page">
-      <header className="flex-shrink-0 p-8 border-b border-[rgb(var(--border-subtle))]">
-        <div className="max-w-[2000px] mx-auto">
-          <div className="flex items-start justify-between gap-6 mb-6">
+    <div className="relative flex h-full flex-col" data-testid="workspaces-page">
+      <header className="flex-shrink-0 border-b border-[rgb(var(--border-subtle))] p-8">
+        <div className="mx-auto max-w-[2000px]">
+          <div className="mb-6 flex items-start justify-between gap-6">
             <div className="min-w-0 flex-1">
               <h1 className="text-3xl font-bold" data-testid="workspaces-title">
                 Workspaces
               </h1>
-              <p className="text-base text-[rgb(var(--muted))] mt-2 max-w-2xl">
-                Map a folder to the tools it should get. When you open that
-                folder in a connected app — Cursor, VS Code, Claude — McpMux
-                serves exactly the tools you chose for it. Folders you
-                haven&apos;t mapped fall back to your default Starter set, so
-                they work out of the box — map one only when it should see
-                something different.
+              <p className="mt-2 max-w-2xl text-base text-[rgb(var(--muted))]">
+                Map a folder to the tools it should get. When you open that folder in a connected
+                app — Cursor, VS Code, Claude — McpMux serves exactly the tools you chose for it.
+                Folders you haven&apos;t mapped fall back to your default Starter set, so they work
+                out of the box — map one only when it should see something different.
               </p>
             </div>
-            <div className="flex-shrink-0 flex items-center gap-2">
+            <div className="flex flex-shrink-0 items-center gap-2">
               <Button
                 variant="ghost"
                 size="md"
@@ -344,7 +326,7 @@ export function WorkspacesPage() {
                 disabled={isRefreshing}
                 className="whitespace-nowrap"
               >
-                <RefreshCw className={`h-4 w-4 mr-2 ${isRefreshing ? 'animate-spin' : ''}`} />
+                <RefreshCw className={`mr-2 h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
                 Refresh
               </Button>
               <Button
@@ -354,21 +336,21 @@ export function WorkspacesPage() {
                 data-testid="workspace-binding-create-toggle"
                 className="whitespace-nowrap"
               >
-                <Plus className="h-4 w-4 mr-2" />
+                <Plus className="mr-2 h-4 w-4" />
                 New mapping
               </Button>
             </div>
           </div>
 
-          <div className="flex flex-wrap items-center gap-3 max-w-3xl">
-            <div className="relative flex-1 min-w-[220px]">
-              <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-[rgb(var(--muted))]" />
+          <div className="flex max-w-3xl flex-wrap items-center gap-3">
+            <div className="relative min-w-[220px] flex-1">
+              <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-[rgb(var(--muted))]" />
               <input
                 type="text"
                 placeholder="Search by path, space, or feature set…"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-12 pr-4 py-3 text-base bg-[rgb(var(--surface))] border border-[rgb(var(--border))] rounded-xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-all"
+                className="focus:ring-primary-500 focus:border-primary-500 w-full rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))] py-3 pl-12 pr-4 text-base transition-all focus:outline-none focus:ring-2"
                 data-testid="workspace-binding-search"
               />
             </div>
@@ -391,7 +373,7 @@ export function WorkspacesPage() {
                 className="whitespace-nowrap text-amber-600 hover:bg-amber-50 hover:text-amber-700 dark:text-amber-400 dark:hover:bg-amber-900/20"
                 data-testid="workspaces-clear-unmapped"
               >
-                <Trash2 className="h-4 w-4 mr-2" />
+                <Trash2 className="mr-2 h-4 w-4" />
                 Clear unmapped
               </Button>
             )}
@@ -401,17 +383,17 @@ export function WorkspacesPage() {
 
       {error && (
         <div className="flex-shrink-0 px-8 pt-6">
-          <div className="max-w-[2000px] mx-auto p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-base text-red-600 dark:text-red-400">
+          <div className="mx-auto max-w-[2000px] rounded-xl border border-red-200 bg-red-50 p-4 text-base text-red-600 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
             {error}
           </div>
         </div>
       )}
 
       <div className="flex-1 overflow-auto px-8 py-8">
-        <div className="max-w-[2000px] mx-auto">
+        <div className="mx-auto max-w-[2000px]">
           {isLoading ? (
-            <div className="flex items-center justify-center h-64">
-              <Loader2 className="h-8 w-8 animate-spin text-primary-500" />
+            <div className="flex h-64 items-center justify-center">
+              <Loader2 className="text-primary-500 h-8 w-8 animate-spin" />
             </div>
           ) : filtered.length === 0 ? (
             <EmptyState
@@ -420,10 +402,9 @@ export function WorkspacesPage() {
               onCreate={() => setSelected({ mode: 'new' })}
             />
           ) : (
-            <div className="grid gap-5 auto-fill-cards">
+            <div className="auto-fill-cards grid gap-5">
               {filtered.map((entry) => {
-                const isSelected =
-                  selected?.mode === 'entry' && selected.id === entry.id;
+                const isSelected = selected?.mode === 'entry' && selected.id === entry.id;
                 // Mapped entries show their bound Space + FeatureSet names.
                 // Unmapped entries read "Not mapped" — they fall back to the
                 // default Starter set rather than to an explicit binding.
@@ -431,9 +412,7 @@ export function WorkspacesPage() {
                   ? spaceById.get(entry.binding.space_id)?.name
                   : undefined;
                 const fsNames = entry.binding
-                  ? entry.binding.feature_set_ids.map(
-                      (id) => fsById.get(id)?.name ?? id
-                    )
+                  ? entry.binding.feature_set_ids.map((id) => fsById.get(id)?.name ?? id)
                   : [];
                 return (
                   <EntryCard
@@ -454,7 +433,7 @@ export function WorkspacesPage() {
       {panelOpen && (
         <>
           <div
-            className="fixed inset-0 bg-black/20 backdrop-blur-[2px] z-40 animate-in fade-in duration-200"
+            className="animate-in fade-in fixed inset-0 z-40 bg-black/20 backdrop-blur-[2px] duration-200"
             onClick={() => setSelected(null)}
           />
           {selectedIsNew ? (
@@ -548,7 +527,7 @@ function SegmentedFilter<T extends string>({
   options: Array<{ value: T; label: string; count?: number }>;
 }) {
   return (
-    <div className="inline-flex rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-0.5 gap-0.5">
+    <div className="inline-flex gap-0.5 rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-0.5">
       {options.map((o) => {
         const active = o.value === value;
         return (
@@ -559,7 +538,7 @@ function SegmentedFilter<T extends string>({
             data-testid={`workspace-filter-${o.value}`}
             aria-pressed={active}
             className={[
-              'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-all',
+              'inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-all',
               active
                 ? 'bg-[rgb(var(--background))] text-[rgb(var(--foreground))] shadow-sm'
                 : 'text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]',
@@ -568,7 +547,7 @@ function SegmentedFilter<T extends string>({
             {o.label}
             {typeof o.count === 'number' && (
               <span
-                className={`inline-flex items-center justify-center min-w-[1.25rem] h-[1.125rem] px-1 text-[10px] font-semibold rounded-full ${
+                className={`inline-flex h-[1.125rem] min-w-[1.25rem] items-center justify-center rounded-full px-1 text-[10px] font-semibold ${
                   active
                     ? 'bg-[rgb(var(--surface))] text-[rgb(var(--foreground))]'
                     : 'bg-[rgb(var(--surface-hover,var(--surface)))] text-[rgb(var(--muted))]'
@@ -645,18 +624,14 @@ function EntryCard({
   onClick: () => void;
 }) {
   const tone =
-    entry.kind === 'unmapped-live'
-      ? 'amber'
-      : entry.kind === 'mapped-live'
-        ? 'emerald'
-        : 'neutral';
+    entry.kind === 'unmapped-live' ? 'amber' : entry.kind === 'mapped-live' ? 'emerald' : 'neutral';
   const t = CARD_TONES[tone];
   const name = folderName(entry.root);
 
   return (
     <Card
-      className={`relative cursor-pointer overflow-hidden transition-all hover:shadow-lg hover:scale-[1.01] ${
-        selected ? 'ring-2 ring-primary-500 shadow-lg' : ''
+      className={`relative cursor-pointer overflow-hidden transition-all hover:scale-[1.01] hover:shadow-lg ${
+        selected ? 'ring-primary-500 shadow-lg ring-2' : ''
       }`}
       onClick={onClick}
       data-testid={`workspace-entry-${entry.id}`}
@@ -669,11 +644,7 @@ function EntryCard({
             <div
               className={`flex h-14 w-14 items-center justify-center rounded-xl ring-1 ring-inset ${t.box}`}
             >
-              {entry.isLive ? (
-                <FolderOpen className="h-6 w-6" />
-              ) : (
-                <Folder className="h-6 w-6" />
-              )}
+              {entry.isLive ? <FolderOpen className="h-6 w-6" /> : <Folder className="h-6 w-6" />}
             </div>
             {entry.isLive && (
               <span
@@ -691,10 +662,7 @@ function EntryCard({
             <h3 className="truncate text-base font-semibold" title={entry.root}>
               {name}
             </h3>
-            <p
-              className="truncate font-mono text-xs text-[rgb(var(--muted))]"
-              title={entry.root}
-            >
+            <p className="truncate font-mono text-xs text-[rgb(var(--muted))]" title={entry.root}>
               {entry.root}
             </p>
           </div>
@@ -704,7 +672,7 @@ function EntryCard({
           {entry.binding ? (
             <div className="flex items-center justify-between gap-3">
               <span className="inline-flex min-w-0 items-center gap-1.5">
-                <Layers className="h-3.5 w-3.5 flex-shrink-0 text-primary-500" />
+                <Layers className="text-primary-500 h-3.5 w-3.5 flex-shrink-0" />
                 <span
                   className="truncate font-medium text-[rgb(var(--foreground))]"
                   title={fsNames.join(', ')}
@@ -713,7 +681,7 @@ function EntryCard({
                 </span>
                 {fsNames.length > 1 && (
                   <span
-                    className="flex-shrink-0 rounded-full bg-primary-500/10 px-1.5 text-[10px] font-bold tabular-nums text-primary-600 dark:text-primary-300"
+                    className="bg-primary-500/10 text-primary-600 dark:text-primary-300 flex-shrink-0 rounded-full px-1.5 text-[10px] font-bold tabular-nums"
                     title={`${fsNames.length} feature sets`}
                   >
                     {fsNames.length}
@@ -752,27 +720,21 @@ function Pill({
         : 'bg-[rgb(var(--surface))] text-[rgb(var(--muted))] border-[rgb(var(--border-subtle))]';
   return (
     <span
-      className={`inline-flex items-center px-1.5 py-0.5 rounded-md border text-[10px] font-semibold uppercase tracking-wider ${cls}`}
+      className={`inline-flex items-center rounded-md border px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${cls}`}
     >
       {children}
     </span>
   );
 }
 
-function Chip({
-  children,
-  tone,
-}: {
-  children: React.ReactNode;
-  tone: 'primary' | 'neutral';
-}) {
+function Chip({ children, tone }: { children: React.ReactNode; tone: 'primary' | 'neutral' }) {
   const styles =
     tone === 'primary'
       ? 'bg-primary-50 dark:bg-primary-900/20 text-primary-700 dark:text-primary-300 border-primary-200 dark:border-primary-800/60'
       : 'bg-[rgb(var(--surface))] border-[rgb(var(--border-subtle))] text-[rgb(var(--foreground))]';
   return (
     <span
-      className={`inline-flex items-center px-1.5 py-0.5 rounded-md border text-[11px] font-medium ${styles}`}
+      className={`inline-flex items-center rounded-md border px-1.5 py-0.5 text-[11px] font-medium ${styles}`}
     >
       {children}
     </span>
@@ -804,8 +766,7 @@ const SECTION_TONES: Record<SectionTone, SectionToneSpec> = {
   primary: {
     gradientOpen:
       'bg-gradient-to-r from-primary-50 to-primary-100/50 dark:from-primary-900/20 dark:to-primary-800/10',
-    iconQuiet:
-      'bg-primary-100 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400',
+    iconQuiet: 'bg-primary-100 dark:bg-primary-900/30 text-primary-600 dark:text-primary-400',
     iconActive: 'bg-primary-500 text-white shadow-sm shadow-primary-500/30',
     badgeOpen:
       'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 border border-primary-300/70 dark:border-primary-700/70',
@@ -813,8 +774,7 @@ const SECTION_TONES: Record<SectionTone, SectionToneSpec> = {
   purple: {
     gradientOpen:
       'bg-gradient-to-r from-purple-50 to-pink-50 dark:from-purple-900/20 dark:to-pink-900/15',
-    iconQuiet:
-      'bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400',
+    iconQuiet: 'bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400',
     iconActive: 'bg-purple-500 text-white shadow-sm shadow-purple-500/30',
     badgeOpen:
       'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 border border-purple-300/70 dark:border-purple-700/70',
@@ -848,41 +808,37 @@ function CollapsibleSection({
 
   return (
     <div
-      className="bg-[rgb(var(--background))] rounded-xl border-2 border-[rgb(var(--border))] overflow-hidden transition-all"
+      className="overflow-hidden rounded-xl border-2 border-[rgb(var(--border))] bg-[rgb(var(--background))] transition-all"
       data-testid={testId}
     >
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         className={[
-          'w-full flex items-center justify-between p-4 transition-all',
-          open
-            ? t.gradientOpen
-            : 'bg-[rgb(var(--surface))] hover:bg-[rgb(var(--surface-hover))]',
+          'flex w-full items-center justify-between p-4 transition-all',
+          open ? t.gradientOpen : 'bg-[rgb(var(--surface))] hover:bg-[rgb(var(--surface-hover))]',
         ].join(' ')}
         aria-expanded={open}
       >
-        <div className="flex items-center gap-3 min-w-0 flex-1">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
           <div
             className={[
-              'p-2 rounded-lg flex-shrink-0 transition-colors duration-200',
+              'flex-shrink-0 rounded-lg p-2 transition-colors duration-200',
               open ? t.iconActive : t.iconQuiet,
             ].join(' ')}
           >
             {icon}
           </div>
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2 flex-wrap">
-              <span className="font-semibold text-base text-[rgb(var(--foreground))]">
-                {title}
-              </span>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-base font-semibold text-[rgb(var(--foreground))]">{title}</span>
               {typeof badge === 'number' && badge > 0 && (
                 <span
                   className={[
-                    'text-xs px-2 py-0.5 rounded-full font-bold tabular-nums',
+                    'rounded-full px-2 py-0.5 text-xs font-bold tabular-nums',
                     open
                       ? t.badgeOpen
-                      : 'bg-[rgb(var(--surface-dim))] text-[rgb(var(--muted))] border border-[rgb(var(--border-subtle))]',
+                      : 'border border-[rgb(var(--border-subtle))] bg-[rgb(var(--surface-dim))] text-[rgb(var(--muted))]',
                   ].join(' ')}
                 >
                   {badge}
@@ -891,21 +847,19 @@ function CollapsibleSection({
               {headerExtra}
             </div>
             {subtitle && (
-              <div className="text-xs text-[rgb(var(--muted))] truncate mt-0.5">
-                {subtitle}
-              </div>
+              <div className="mt-0.5 truncate text-xs text-[rgb(var(--muted))]">{subtitle}</div>
             )}
           </div>
         </div>
         {open ? (
-          <ChevronDown className="h-5 w-5 text-[rgb(var(--muted))] flex-shrink-0" />
+          <ChevronDown className="h-5 w-5 flex-shrink-0 text-[rgb(var(--muted))]" />
         ) : (
-          <ChevronRight className="h-5 w-5 text-[rgb(var(--muted))] flex-shrink-0" />
+          <ChevronRight className="h-5 w-5 flex-shrink-0 text-[rgb(var(--muted))]" />
         )}
       </button>
 
       {open && (
-        <div className="border-t-2 border-[rgb(var(--border))] bg-white dark:bg-[rgb(var(--background))] p-4">
+        <div className="border-t-2 border-[rgb(var(--border))] bg-white p-4 dark:bg-[rgb(var(--background))]">
           {children}
         </div>
       )}
@@ -958,14 +912,8 @@ function InspectorPanel({
     : isMapped
       ? 'edit'
       : 'create-from-live';
-  const title = isNew
-    ? 'New mapping'
-    : isMapped
-      ? 'Workspace mapping'
-      : 'Map this folder';
-  const subtitle = isNew
-    ? 'Choose the tools a folder should get.'
-    : entry?.root ?? '';
+  const title = isNew ? 'New mapping' : isMapped ? 'Workspace mapping' : 'Map this folder';
+  const subtitle = isNew ? 'Choose the tools a folder should get.' : (entry?.root ?? '');
 
   // Auto-save status drives the small pill in the Mapping section header.
   const [saveStatus, setSaveStatus] = useState<SaveStatus>({ kind: 'idle' });
@@ -975,22 +923,24 @@ function InspectorPanel({
   const [effectiveTotal, setEffectiveTotal] = useState<number | null>(null);
 
   return (
-    <div className="fixed right-0 top-0 bottom-0 w-full max-w-[480px] min-w-[420px] bg-[rgb(var(--surface))] border-l border-[rgb(var(--border))] shadow-2xl flex flex-col animate-in slide-in-from-right duration-300 z-50">
-      <div className="flex-shrink-0 p-4 border-b border-[rgb(var(--border))] bg-[rgb(var(--surface-elevated))]">
+    <div className="animate-in slide-in-from-right fixed bottom-0 right-0 top-0 z-50 flex w-full min-w-[420px] max-w-[480px] flex-col border-l border-[rgb(var(--border))] bg-[rgb(var(--surface))] shadow-2xl duration-300">
+      <div className="flex-shrink-0 border-b border-[rgb(var(--border))] bg-[rgb(var(--surface-elevated))] p-4">
         <div className="flex items-start justify-between">
-          <div className="flex items-center gap-3 flex-1 min-w-0">
-            <div className="w-11 h-11 flex items-center justify-center bg-[rgb(var(--background))] rounded-lg flex-shrink-0 border border-[rgb(var(--border-subtle))]">
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-lg border border-[rgb(var(--border-subtle))] bg-[rgb(var(--background))]">
               <FolderOpen className="h-5 w-5 text-[rgb(var(--muted))]" />
             </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-0.5 flex-wrap">
+            <div className="min-w-0 flex-1">
+              <div className="mb-0.5 flex flex-wrap items-center gap-2">
                 {!isNew && entry?.isLive && <Pill tone="emerald">Live</Pill>}
                 {!isNew && entry && !isMapped && <Pill tone="amber">Unmapped</Pill>}
-                {!isNew && entry && isMapped && !entry.isLive && <Pill tone="neutral">Offline</Pill>}
+                {!isNew && entry && isMapped && !entry.isLive && (
+                  <Pill tone="neutral">Offline</Pill>
+                )}
               </div>
-              <h2 className="text-lg font-bold truncate">{title}</h2>
+              <h2 className="truncate text-lg font-bold">{title}</h2>
               <p
-                className={`text-xs text-[rgb(var(--muted))] truncate ${!isNew ? 'font-mono' : ''}`}
+                className={`truncate text-xs text-[rgb(var(--muted))] ${!isNew ? 'font-mono' : ''}`}
                 title={subtitle}
               >
                 {subtitle}
@@ -999,7 +949,7 @@ function InspectorPanel({
           </div>
           <button
             onClick={onClose}
-            className="p-1.5 rounded-lg hover:bg-[rgb(var(--surface-hover))] transition-colors flex-shrink-0"
+            className="flex-shrink-0 rounded-lg p-1.5 transition-colors hover:bg-[rgb(var(--surface-hover))]"
             aria-label="Close panel"
           >
             <X className="h-5 w-5" />
@@ -1007,7 +957,7 @@ function InspectorPanel({
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-6 space-y-5">
+      <div className="flex-1 space-y-5 overflow-y-auto p-6">
         <CollapsibleSection
           icon={<FolderOpen className="h-5 w-5" />}
           tone="primary"
@@ -1024,9 +974,7 @@ function InspectorPanel({
                           (id) => featureSets.find((f) => f.id === id)?.name ?? id
                         )
                       ) || '—'
-                    } from ${
-                      spaces.find((s) => s.id === entry.binding!.space_id)?.name ?? '—'
-                    }`
+                    } from ${spaces.find((s) => s.id === entry.binding!.space_id)?.name ?? '—'}`
                   : 'Edit what this folder sees, then press Apply.'
           }
           defaultOpen={isNew || !isMapped}
@@ -1070,24 +1018,21 @@ function InspectorPanel({
             badge={effectiveTotal ?? undefined}
             testId="workspace-effective-features-section"
           >
-            <EffectiveFeaturesContent
-              root={entry.root}
-              onTotalChange={setEffectiveTotal}
-            />
+            <EffectiveFeaturesContent root={entry.root} onTotalChange={setEffectiveTotal} />
           </CollapsibleSection>
         )}
       </div>
 
       {entry?.binding && (
-        <div className="flex-shrink-0 p-4 border-t border-[rgb(var(--border))] bg-[rgb(var(--surface-elevated))]">
+        <div className="flex-shrink-0 border-t border-[rgb(var(--border))] bg-[rgb(var(--surface-elevated))] p-4">
           <Button
             variant="ghost"
             size="sm"
             onClick={() => void onDelete()}
-            className="w-full text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
+            className="w-full text-red-600 hover:bg-red-50 hover:text-red-700 dark:hover:bg-red-900/20"
             data-testid={`workspace-binding-delete-${entry.binding.id}`}
           >
-            <Trash2 className="h-4 w-4 mr-2" />
+            <Trash2 className="mr-2 h-4 w-4" />
             Remove mapping
           </Button>
         </div>
@@ -1103,7 +1048,7 @@ function SaveStatusPill({ status }: { status: SaveStatus }) {
   if (status.kind === 'saving') {
     return (
       <span
-        className={`${base} bg-[rgb(var(--surface-dim))] text-[rgb(var(--muted))] border-[rgb(var(--border))]`}
+        className={`${base} border-[rgb(var(--border))] bg-[rgb(var(--surface-dim))] text-[rgb(var(--muted))]`}
       >
         <Loader2 className="h-2.5 w-2.5 animate-spin" />
         Saving
@@ -1113,7 +1058,7 @@ function SaveStatusPill({ status }: { status: SaveStatus }) {
   if (status.kind === 'saved') {
     return (
       <span
-        className={`${base} bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 border-green-300/70 dark:border-green-700/70 animate-in fade-in duration-200`}
+        className={`${base} animate-in fade-in border-green-300/70 bg-green-100 text-green-700 duration-200 dark:border-green-700/70 dark:bg-green-900/30 dark:text-green-300`}
       >
         <Check className="h-2.5 w-2.5" strokeWidth={2.5} />
         Saved
@@ -1122,7 +1067,7 @@ function SaveStatusPill({ status }: { status: SaveStatus }) {
   }
   return (
     <span
-      className={`${base} bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 border-red-200 dark:border-red-800`}
+      className={`${base} border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400`}
       title={status.message}
     >
       <AlertCircle className="h-2.5 w-2.5" />
@@ -1160,9 +1105,7 @@ function buildServerGroups(data: WorkspaceEffectiveFeatures): ServerGroup[] {
     let g = map.get(item.server_id);
     if (!g) {
       const totals = data.server_totals[item.server_id];
-      const server_total = totals
-        ? totals.tools + totals.prompts + totals.resources
-        : 0;
+      const server_total = totals ? totals.tools + totals.prompts + totals.resources : 0;
       g = {
         server_id: item.server_id,
         server_alias: item.server_alias ?? item.server_id,
@@ -1298,8 +1241,8 @@ function EffectiveFeaturesContent({
   }
   if (error) {
     return (
-      <div className="p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 flex items-start gap-2 text-sm text-red-600 dark:text-red-400">
-        <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+      <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-600 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+        <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
         <span>{error}</span>
       </div>
     );
@@ -1313,12 +1256,12 @@ function EffectiveFeaturesContent({
     <div className="space-y-4">
       {/* Resolution summary — bold pills showing what this folder
           resolves to, plus a progress bar for availability. */}
-      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-3 space-y-2.5">
-        <div className="flex items-center gap-2 flex-wrap">
+      <div className="space-y-2.5 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-3">
+        <div className="flex flex-wrap items-center gap-2">
           <span className="text-[10px] font-bold uppercase tracking-wider text-[rgb(var(--muted))]">
             Resolves to
           </span>
-          <span className="text-sm font-semibold text-[rgb(var(--foreground))] truncate">
+          <span className="truncate text-sm font-semibold text-[rgb(var(--foreground))]">
             {formatFsList(data.feature_sets.map((fs) => fs.name)) || '—'}
           </span>
           <span className="text-xs text-[rgb(var(--muted))]">in</span>
@@ -1332,10 +1275,10 @@ function EffectiveFeaturesContent({
                 : 'No binding matches this folder, so it falls back to the default Starter set shown here. Map it to give this folder a different set.'
             }
             className={[
-              'ml-auto text-[10px] px-2 py-0.5 rounded-full font-bold uppercase tracking-wider border',
+              'ml-auto rounded-full border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider',
               data.source === 'binding'
-                ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 border-purple-300/70 dark:border-purple-700/70'
-                : 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-300/70 dark:border-amber-700/70',
+                ? 'border-purple-300/70 bg-purple-100 text-purple-700 dark:border-purple-700/70 dark:bg-purple-900/30 dark:text-purple-300'
+                : 'border-amber-300/70 bg-amber-100 text-amber-700 dark:border-amber-700/70 dark:bg-amber-900/30 dark:text-amber-300',
             ].join(' ')}
           >
             {data.source === 'binding' ? 'binding' : 'unbound'}
@@ -1346,7 +1289,7 @@ function EffectiveFeaturesContent({
             are connected, leans amber when some are dim. */}
         <div className="space-y-1.5">
           <div className="flex items-center justify-between text-xs">
-            <span className="text-[rgb(var(--muted))] tabular-nums">
+            <span className="tabular-nums text-[rgb(var(--muted))]">
               <span className="font-semibold text-[rgb(var(--foreground))]">{availableCount}</span>
               <span> of </span>
               <span className="font-semibold text-[rgb(var(--foreground))]">{totalCount}</span>
@@ -1367,7 +1310,7 @@ function EffectiveFeaturesContent({
               </span>
             )}
           </div>
-          <div className="h-1.5 bg-gray-200 dark:bg-gray-800 rounded-full overflow-hidden">
+          <div className="h-1.5 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-800">
             <div
               className={[
                 'h-full transition-all duration-300',
@@ -1389,12 +1332,12 @@ function EffectiveFeaturesContent({
 
       {/* Server-grouped feature list. */}
       {groups.length === 0 ? (
-        <div className="text-center py-8 text-[rgb(var(--muted))]">
-          <Package className="h-8 w-8 mx-auto mb-2 opacity-50" />
+        <div className="py-8 text-center text-[rgb(var(--muted))]">
+          <Package className="mx-auto mb-2 h-8 w-8 opacity-50" />
           <p className="text-sm">No features configured in this feature set yet.</p>
         </div>
       ) : (
-        <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] overflow-hidden">
+        <div className="overflow-hidden rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))]">
           <div className="divide-y divide-[rgb(var(--border))]">
             {groups.map((g) => (
               <ServerGroupRow
@@ -1432,46 +1375,38 @@ function ServerGroupRow({
 
   // Strip reverse-DNS prefix so display reads "cloudflare-bindings" not
   // "com.cloudflare-bindings". The full id stays in title for hover.
-  const prefix = group.server_alias.includes('.')
-    ? group.server_alias.split('.', 2)[0]
-    : null;
-  const displayName = prefix
-    ? group.server_alias.slice(prefix.length + 1)
-    : group.server_alias;
+  const prefix = group.server_alias.includes('.') ? group.server_alias.split('.', 2)[0] : null;
+  const displayName = prefix ? group.server_alias.slice(prefix.length + 1) : group.server_alias;
 
   return (
     <div className="bg-[rgb(var(--surface))]">
       <div
-        className="flex items-center justify-between px-4 py-3 hover:bg-[rgb(var(--surface-hover))] cursor-pointer transition-colors"
+        className="flex cursor-pointer items-center justify-between px-4 py-3 transition-colors hover:bg-[rgb(var(--surface-hover))]"
         onClick={onToggle}
         role="button"
         title={group.server_alias}
       >
-        <div className="flex items-center gap-3 flex-1 min-w-0">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
           {open ? (
-            <ChevronDown className="h-4 w-4 text-[rgb(var(--muted))] flex-shrink-0" />
+            <ChevronDown className="h-4 w-4 flex-shrink-0 text-[rgb(var(--muted))]" />
           ) : (
-            <ChevronRight className="h-4 w-4 text-[rgb(var(--muted))] flex-shrink-0" />
+            <ChevronRight className="h-4 w-4 flex-shrink-0 text-[rgb(var(--muted))]" />
           )}
-          <ServerIcon className="h-4 w-4 text-blue-500 flex-shrink-0" />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1 flex-wrap">
+          <ServerIcon className="h-4 w-4 flex-shrink-0 text-blue-500" />
+          <div className="min-w-0 flex-1">
+            <div className="mb-1 flex flex-wrap items-center gap-2">
               {prefix && (
-                <span className="text-[10px] text-[rgb(var(--muted))] font-mono">
-                  {prefix}.
-                </span>
+                <span className="font-mono text-[10px] text-[rgb(var(--muted))]">{prefix}.</span>
               )}
-              <span className="font-medium text-sm truncate font-mono">
-                {displayName}
-              </span>
+              <span className="truncate font-mono text-sm font-medium">{displayName}</span>
               <span
                 className={[
-                  'text-xs px-2 py-0.5 rounded-full font-bold flex-shrink-0 tabular-nums',
+                  'flex-shrink-0 rounded-full px-2 py-0.5 text-xs font-bold tabular-nums',
                   noneAvailable
-                    ? 'bg-gray-100 dark:bg-gray-900/30 text-gray-600 dark:text-gray-400 border border-gray-300/70 dark:border-gray-700/70'
+                    ? 'border border-gray-300/70 bg-gray-100 text-gray-600 dark:border-gray-700/70 dark:bg-gray-900/30 dark:text-gray-400'
                     : allAvailable
-                      ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300 border border-green-300/70 dark:border-green-700/70'
-                      : 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border border-amber-300/70 dark:border-amber-700/70',
+                      ? 'border border-green-300/70 bg-green-100 text-green-700 dark:border-green-700/70 dark:bg-green-900/30 dark:text-green-300'
+                      : 'border border-amber-300/70 bg-amber-100 text-amber-700 dark:border-amber-700/70 dark:bg-amber-900/30 dark:text-amber-300',
                 ].join(' ')}
               >
                 {group.mapped}/{denominator}
@@ -1479,12 +1414,12 @@ function ServerGroupRow({
               {issue && (
                 <span
                   className={[
-                    'text-[10px] px-1.5 py-0.5 rounded-full font-bold uppercase tracking-wider border',
+                    'rounded-full border px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider',
                     issue.tone === 'red'
-                      ? 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 border-red-200 dark:border-red-800'
+                      ? 'border-red-200 bg-red-50 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400'
                       : issue.tone === 'amber'
-                        ? 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800'
-                        : 'bg-gray-50 dark:bg-gray-900/20 text-gray-600 dark:text-gray-400 border-gray-200 dark:border-gray-800',
+                        ? 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-400'
+                        : 'border-gray-200 bg-gray-50 text-gray-600 dark:border-gray-800 dark:bg-gray-900/20 dark:text-gray-400',
                   ].join(' ')}
                 >
                   {issue.label}
@@ -1493,7 +1428,7 @@ function ServerGroupRow({
             </div>
             {/* Per-server progress bar — same treatment as FeatureSetPanel's
                 server rows so the visual language is consistent. */}
-            <div className="h-1 bg-gray-200 dark:bg-gray-800 rounded-full overflow-hidden">
+            <div className="h-1 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-800">
               <div
                 className={[
                   'h-full transition-all duration-300',
@@ -1506,10 +1441,7 @@ function ServerGroupRow({
                         : 'bg-gray-400',
                 ].join(' ')}
                 style={{
-                  width:
-                    group.mapped > 0
-                      ? `${(availableCount / group.mapped) * 100}%`
-                      : '0%',
+                  width: group.mapped > 0 ? `${(availableCount / group.mapped) * 100}%` : '0%',
                 }}
               />
             </div>
@@ -1518,7 +1450,7 @@ function ServerGroupRow({
       </div>
 
       {open && (
-        <div className="bg-[rgb(var(--background))] border-t border-[rgb(var(--border))]">
+        <div className="border-t border-[rgb(var(--border))] bg-[rgb(var(--background))]">
           <FeatureSubGroup label="tool" items={group.tools} />
           <FeatureSubGroup label="prompt" items={group.prompts} />
           <FeatureSubGroup label="resource" items={group.resources} />
@@ -1547,33 +1479,33 @@ function FeatureSubGroup({
         <div
           key={item.id}
           className={[
-            'flex items-start gap-3 px-4 py-2.5 pl-12 border-b border-[rgb(var(--border))] last:border-b-0',
+            'flex items-start gap-3 border-b border-[rgb(var(--border))] px-4 py-2.5 pl-12 last:border-b-0',
             !item.available ? 'opacity-50' : '',
           ].join(' ')}
           title={item.description ?? item.feature_name}
         >
           {getFeatureTypeIcon(label)}
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 flex-wrap">
-              <span className="font-medium text-sm truncate font-mono">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="truncate font-mono text-sm font-medium">
                 {item.display_name || item.feature_name}
               </span>
               <span
                 className={[
-                  'text-[10px] px-1.5 py-0.5 rounded font-medium',
+                  'rounded px-1.5 py-0.5 text-[10px] font-medium',
                   getFeatureTypeColor(label),
                 ].join(' ')}
               >
                 {label}
               </span>
               {!item.available && (
-                <span className="text-[9px] uppercase tracking-wider font-bold text-[rgb(var(--muted))]">
+                <span className="text-[9px] font-bold uppercase tracking-wider text-[rgb(var(--muted))]">
                   unavailable
                 </span>
               )}
             </div>
             {item.description && (
-              <p className="text-xs text-[rgb(var(--muted))] mt-0.5 line-clamp-1">
+              <p className="mt-0.5 line-clamp-1 text-xs text-[rgb(var(--muted))]">
                 {item.description}
               </p>
             )}
@@ -1587,11 +1519,11 @@ function FeatureSubGroup({
 function getFeatureTypeIcon(type: 'tool' | 'prompt' | 'resource') {
   switch (type) {
     case 'tool':
-      return <Wrench className="h-4 w-4 text-purple-500 flex-shrink-0 mt-0.5" />;
+      return <Wrench className="mt-0.5 h-4 w-4 flex-shrink-0 text-purple-500" />;
     case 'prompt':
-      return <MessageSquare className="h-4 w-4 text-blue-500 flex-shrink-0 mt-0.5" />;
+      return <MessageSquare className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-500" />;
     case 'resource':
-      return <FileText className="h-4 w-4 text-green-500 flex-shrink-0 mt-0.5" />;
+      return <FileText className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" />;
   }
 }
 
@@ -1676,6 +1608,10 @@ function BindingForm({
   // their members into one allow set). Order is preserved so the operator
   // can rank a "primary" FS first; the resolver itself doesn't care.
   const [fsIds, setFsIds] = useState<string[]>(initial?.feature_set_ids ?? []);
+  // A mapping is keyed by a folder path OR an arbitrary id/label. The type is
+  // chosen at create time and fixed thereafter (an id never becomes a folder).
+  const [bindingType, setBindingType] = useState<'path' | 'id'>(initial?.binding_type ?? 'path');
+  const isId = bindingType === 'id';
   const [fsSearch, setFsSearch] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const isEdit = mode === 'edit';
@@ -1708,6 +1644,11 @@ function BindingForm({
       setRootValidation({ state: 'ok', normalized: root });
       return;
     }
+    if (isId) {
+      // Id keys are matched verbatim — skip filesystem-path validation.
+      setRootValidation(root.trim() ? { state: 'ok', normalized: root.trim() } : { state: 'idle' });
+      return;
+    }
     if (!root.trim()) {
       setRootValidation({ state: 'idle' });
       return;
@@ -1724,15 +1665,11 @@ function BindingForm({
         .catch((e: unknown) => {
           if (validationSeq.current !== seq) return;
           const reason = typeof e === 'string' ? e : String(e);
-          setRootValidation(
-            reason === ''
-              ? { state: 'idle' }
-              : { state: 'error', reason }
-          );
+          setRootValidation(reason === '' ? { state: 'idle' } : { state: 'error', reason });
         });
     }, 180);
     return () => clearTimeout(handle);
-  }, [root, rootEditable]);
+  }, [root, rootEditable, isId]);
 
   useEffect(() => {
     if (mode === 'create') rootRef.current?.focus();
@@ -1779,17 +1716,14 @@ function BindingForm({
   }, [availableFs]);
 
   const toggleFs = (id: string) => {
-    setFsIds((prev) =>
-      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
-    );
+    setFsIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
   };
 
   const trimmedRoot = root.trim();
   // The canonical form the server will store. We prefer the validator's
   // normalized output (drive-letter case, slash direction, trailing slash
   // all settled) so the duplicate check matches exactly what a save writes.
-  const effectiveRoot =
-    rootValidation.state === 'ok' ? rootValidation.normalized : trimmedRoot;
+  const effectiveRoot = rootValidation.state === 'ok' ? rootValidation.normalized : trimmedRoot;
 
   // Has this folder already been mapped? Compare against every saved mapping
   // (case-insensitively, the app's notion of "same folder"), excluding the
@@ -1830,15 +1764,19 @@ function BindingForm({
 
   const handleSubmit = async () => {
     if (!root.trim()) {
-      onError('Pick a folder first.');
+      onError(isId ? 'Enter an id or label.' : 'Pick a folder first.');
       return;
     }
-    if (rootValidation.state === 'error') {
+    if (!isId && rootValidation.state === 'error') {
       onError(rootValidation.reason);
       return;
     }
     if (duplicate) {
-      onError(`That folder is already mapped. Open the existing mapping to change it.`);
+      onError(
+        isId
+          ? 'That id is already mapped. Open its existing mapping to change it.'
+          : `That folder is already mapped. Open the existing mapping to change it.`
+      );
       return;
     }
     if (!spaceId) {
@@ -1856,6 +1794,7 @@ function BindingForm({
         workspace_root: root.trim(),
         space_id: spaceId,
         feature_set_ids: fsIds,
+        binding_type: bindingType,
       });
       onSaveStatusChange?.({ kind: 'saved' });
       savedTimerRef.current = setTimeout(() => {
@@ -1887,15 +1826,34 @@ function BindingForm({
       {/* Plain-language primer for anyone who's never seen McpMux. Explains
           the whole flow in two sentences before the fields. */}
       <div className="rounded-lg border border-[rgb(var(--border-subtle))] bg-[rgb(var(--surface))] px-3.5 py-3 text-xs leading-relaxed text-[rgb(var(--muted))]">
-        <span className="font-semibold text-[rgb(var(--foreground))]">
-          What is a mapping?
-        </span>{' '}
-        Pick a folder, then choose the tools it should get. Whenever you open
-        that folder in a connected app — Cursor, VS Code, Claude — McpMux hands
-        it exactly the tools you choose here, and nothing else.
+        <span className="font-semibold text-[rgb(var(--foreground))]">What is a mapping?</span>{' '}
+        {isId
+          ? 'Enter an id or label (a client id, machine name, or any string), then choose the tools it gets. A headless or remote client that sends this exact value in the X-Mcpmux-Workspace header receives exactly those tools.'
+          : 'Pick a folder, then choose the tools it should get. Whenever you open that folder in a connected app — Cursor, VS Code, Claude — McpMux hands it exactly the tools you choose here, and nothing else.'}
       </div>
 
-      <FormField label="Workspace folder">
+      {mode === 'create' && (
+        <div className="flex gap-1 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-1">
+          {(['path', 'id'] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setBindingType(t)}
+              className={[
+                'flex-1 rounded-md px-3 py-1.5 text-xs font-medium transition-colors',
+                bindingType === t
+                  ? 'bg-primary-500 text-white'
+                  : 'text-[rgb(var(--muted))] hover:bg-[rgb(var(--surface-hover))]',
+              ].join(' ')}
+              data-testid={`workspace-binding-type-${t}`}
+            >
+              {t === 'path' ? 'Folder' : 'ID / label'}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <FormField label={isId ? 'Mapping ID / label' : 'Workspace folder'}>
         <div className="flex gap-2">
           <input
             ref={rootRef}
@@ -1903,18 +1861,22 @@ function BindingForm({
             value={root}
             onChange={(e) => setRoot(e.target.value)}
             readOnly={!rootEditable}
-            placeholder="Browse for a folder, or paste an absolute path"
+            placeholder={
+              isId
+                ? 'Any exact-match label — a client id, machine name, etc.'
+                : 'Browse for a folder, or paste an absolute path'
+            }
             className={[
-              'flex-1 min-w-0 px-3 py-2 rounded-lg text-sm font-mono focus:outline-none focus:ring-2',
+              'min-w-0 flex-1 rounded-lg px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2',
               !rootEditable
-                ? 'bg-[rgb(var(--background))] border border-[rgb(var(--border-subtle))] text-[rgb(var(--muted))] cursor-not-allowed focus:ring-primary-500'
+                ? 'focus:ring-primary-500 cursor-not-allowed border border-[rgb(var(--border-subtle))] bg-[rgb(var(--background))] text-[rgb(var(--muted))]'
                 : rootValidation.state === 'error'
-                  ? 'bg-[rgb(var(--background))] border border-red-500/60 focus:ring-red-500 focus:border-red-500'
-                  : 'bg-[rgb(var(--background))] border border-[rgb(var(--border))] focus:ring-primary-500 focus:border-primary-500',
+                  ? 'border border-red-500/60 bg-[rgb(var(--background))] focus:border-red-500 focus:ring-red-500'
+                  : 'focus:ring-primary-500 focus:border-primary-500 border border-[rgb(var(--border))] bg-[rgb(var(--background))]',
             ].join(' ')}
             data-testid="workspace-binding-root-input"
           />
-          {rootEditable && (
+          {rootEditable && !isId && (
             <button
               type="button"
               onClick={async () => {
@@ -1935,7 +1897,7 @@ function BindingForm({
                   onError(e instanceof Error ? e.message : String(e));
                 }
               }}
-              className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))] hover:bg-[rgb(var(--surface-hover))] text-sm font-medium text-[rgb(var(--foreground))] transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 flex-shrink-0"
+              className="focus:ring-primary-500 inline-flex flex-shrink-0 items-center gap-1.5 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-sm font-medium text-[rgb(var(--foreground))] transition-colors hover:bg-[rgb(var(--surface-hover))] focus:outline-none focus:ring-2"
               title="Pick a folder"
               data-testid="workspace-binding-browse"
             >
@@ -1946,21 +1908,22 @@ function BindingForm({
         </div>
         {duplicate ? (
           <p
-            className="mt-1.5 text-[11px] text-red-600 dark:text-red-400 flex items-start gap-1.5"
+            className="mt-1.5 flex items-start gap-1.5 text-[11px] text-red-600 dark:text-red-400"
             data-testid="workspace-binding-duplicate-error"
           >
-            <AlertCircle className="h-3 w-3 flex-shrink-0 mt-px" />
+            <AlertCircle className="mt-px h-3 w-3 flex-shrink-0" />
             <span>
-              This folder is already mapped. Open its existing mapping to change
-              what it sees instead of adding a second one.
+              This folder is already mapped. Open its existing mapping to change what it sees
+              instead of adding a second one.
             </span>
           </p>
+        ) : isId ? (
+          <p className="mt-1.5 text-[11px] text-[rgb(var(--muted))]">
+            Matched exactly (case-sensitive). A client sends this value in the{' '}
+            <code className="font-mono">X-Mcpmux-Workspace</code> header.
+          </p>
         ) : (
-          <RootValidationHint
-            state={rootValidation}
-            editable={rootEditable}
-            originalValue={root}
-          />
+          <RootValidationHint state={rootValidation} editable={rootEditable} originalValue={root} />
         )}
       </FormField>
 
@@ -1982,19 +1945,13 @@ function BindingForm({
       </FormField>
 
       <FormField
-        label={
-          fsIds.length > 1
-            ? `Feature set (${fsIds.length} selected)`
-            : 'Feature set'
-        }
+        label={fsIds.length > 1 ? `Feature set (${fsIds.length} selected)` : 'Feature set'}
         hint="A feature set is a curated list of tools, prompts, and resources from that Space — exactly what this folder is allowed to use. Pick one, or combine several into a single set."
       >
         {!spaceId ? (
-          <p className="text-xs text-[rgb(var(--muted))] italic px-3 py-2">
-            Pick a Space first.
-          </p>
+          <p className="px-3 py-2 text-xs italic text-[rgb(var(--muted))]">Pick a Space first.</p>
         ) : availableFs.length === 0 ? (
-          <p className="text-xs text-[rgb(var(--muted))] italic px-3 py-2">
+          <p className="px-3 py-2 text-xs italic text-[rgb(var(--muted))]">
             No feature sets in that Space yet.
           </p>
         ) : (
@@ -2002,19 +1959,19 @@ function BindingForm({
             className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))]"
             data-testid="workspace-binding-fs"
           >
-            <div className="p-2 border-b border-[rgb(var(--border-subtle))]">
+            <div className="border-b border-[rgb(var(--border-subtle))] p-2">
               <input
                 type="text"
                 value={fsSearch}
                 onChange={(e) => setFsSearch(e.target.value)}
                 placeholder={`Search ${availableFs.length} feature set${availableFs.length === 1 ? '' : 's'}…`}
-                className="w-full px-2.5 py-1.5 text-xs bg-[rgb(var(--surface))] border border-[rgb(var(--border-subtle))] rounded focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="focus:ring-primary-500 w-full rounded border border-[rgb(var(--border-subtle))] bg-[rgb(var(--surface))] px-2.5 py-1.5 text-xs focus:outline-none focus:ring-2"
                 data-testid="workspace-binding-fs-search"
               />
             </div>
-            <div className="max-h-56 overflow-y-auto p-1.5 space-y-1">
+            <div className="max-h-56 space-y-1 overflow-y-auto p-1.5">
               {filteredFs.length === 0 ? (
-                <p className="text-xs text-[rgb(var(--muted))] italic px-2 py-3 text-center">
+                <p className="px-2 py-3 text-center text-xs italic text-[rgb(var(--muted))]">
                   No feature sets match &ldquo;{fsSearch}&rdquo;.
                 </p>
               ) : (
@@ -2027,7 +1984,7 @@ function BindingForm({
                       type="button"
                       onClick={() => toggleFs(f.id)}
                       className={[
-                        'w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded text-left text-sm transition-colors',
+                        'flex w-full items-center gap-2.5 rounded px-2.5 py-1.5 text-left text-sm transition-colors',
                         isSelected
                           ? 'bg-primary-500/10 hover:bg-primary-500/15'
                           : 'hover:bg-[rgb(var(--surface-hover))]',
@@ -2036,30 +1993,25 @@ function BindingForm({
                     >
                       <div
                         className={[
-                          'h-4 w-4 rounded border flex items-center justify-center flex-shrink-0',
+                          'flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border',
                           isSelected
                             ? 'bg-primary-500 border-primary-500'
                             : 'border-[rgb(var(--border-strong))] bg-[rgb(var(--surface))]',
                         ].join(' ')}
                       >
                         {isSelected ? (
-                          <Check
-                            className="h-3 w-3 text-white"
-                            strokeWidth={3}
-                          />
+                          <Check className="h-3 w-3 text-white" strokeWidth={3} />
                         ) : null}
                       </div>
                       {f.icon && (
-                        <span className="text-base leading-none flex-shrink-0">
-                          {f.icon}
-                        </span>
+                        <span className="flex-shrink-0 text-base leading-none">{f.icon}</span>
                       )}
-                      <div className="flex-1 min-w-0">
+                      <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-1.5">
-                          <p className="font-medium truncate">{f.name}</p>
+                          <p className="truncate font-medium">{f.name}</p>
                           {isStarterFeatureSet(f) && (
                             <span
-                              className="text-[9px] uppercase tracking-wide text-[rgb(var(--muted))] bg-[rgb(var(--surface))] px-1 py-0.5 rounded flex-shrink-0"
+                              className="flex-shrink-0 rounded bg-[rgb(var(--surface))] px-1 py-0.5 text-[9px] uppercase tracking-wide text-[rgb(var(--muted))]"
                               title="Auto-seeded with this Space."
                             >
                               starter
@@ -2067,14 +2019,14 @@ function BindingForm({
                           )}
                         </div>
                         {f.description && (
-                          <p className="text-[11px] text-[rgb(var(--muted))] truncate">
+                          <p className="truncate text-[11px] text-[rgb(var(--muted))]">
                             {f.description}
                           </p>
                         )}
                       </div>
                       {order !== null && fsIds.length > 1 && (
                         <span
-                          className="text-[10px] font-bold text-primary-600 dark:text-primary-300 bg-primary-500/15 rounded-full h-5 w-5 flex items-center justify-center flex-shrink-0"
+                          className="text-primary-600 dark:text-primary-300 bg-primary-500/15 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full text-[10px] font-bold"
                           title="Render order — first FS rendered first; resolver merges all into one set."
                         >
                           {order}
@@ -2086,7 +2038,7 @@ function BindingForm({
               )}
             </div>
             {fsSearch && filteredFs.length > 0 && filteredFs.length < availableFs.length && (
-              <div className="px-3 py-1.5 text-[11px] text-[rgb(var(--muted))] border-t border-[rgb(var(--border-subtle))]">
+              <div className="border-t border-[rgb(var(--border-subtle))] px-3 py-1.5 text-[11px] text-[rgb(var(--muted))]">
                 {filteredFs.length} of {availableFs.length} shown
               </div>
             )}
@@ -2099,13 +2051,12 @@ function BindingForm({
           state. In edit mode the button stays disabled until something
           actually changes. An empty feature-set selection is valid and
           savable. */}
-      <div className="pt-1 space-y-2">
+      <div className="space-y-2 pt-1">
         {spaceId && fsIds.length === 0 && (
           // Empty is allowed — explain what it means rather than blocking.
           <p className="text-[11px] text-[rgb(var(--muted))]">
-            No feature sets selected — this folder gets <strong>no tools</strong>{' '}
-            from this Space. Built-in servers still apply per Space (see Built-in
-            Servers).
+            No feature sets selected — this folder gets <strong>no tools</strong> from this Space.
+            Built-in servers still apply per Space (see Built-in Servers).
           </p>
         )}
         {isEdit && dirty && !duplicate && (
@@ -2123,9 +2074,9 @@ function BindingForm({
             data-testid="workspace-binding-submit"
           >
             {submitting ? (
-              <Loader2 className="h-4 w-4 animate-spin mr-1.5" />
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
             ) : (
-              <Check className="h-4 w-4 mr-1.5" />
+              <Check className="mr-1.5 h-4 w-4" />
             )}
             {submitLabel}
           </Button>
@@ -2164,8 +2115,8 @@ function RootValidationHint({
   if (!editable) {
     return (
       <p className="mt-1.5 text-[11px] text-[rgb(var(--muted))]">
-        This folder was reported by the app that&apos;s open in it, so the path
-        is fixed — just choose its tools below.
+        This folder was reported by the app that&apos;s open in it, so the path is fixed — just
+        choose its tools below.
       </p>
     );
   }
@@ -2179,35 +2130,24 @@ function RootValidationHint({
   }
   if (state.state === 'checking') {
     return (
-      <p className="mt-1.5 text-[11px] text-[rgb(var(--muted))] inline-flex items-center gap-1.5">
+      <p className="mt-1.5 inline-flex items-center gap-1.5 text-[11px] text-[rgb(var(--muted))]">
         <Loader2 className="h-3 w-3 animate-spin" />
         Checking…
       </p>
     );
   }
   if (state.state === 'error') {
-    return (
-      <p className="mt-1.5 text-[11px] text-red-600 dark:text-red-400">
-        {state.reason}
-      </p>
-    );
+    return <p className="mt-1.5 text-[11px] text-red-600 dark:text-red-400">{state.reason}</p>;
   }
   // ok
   const changed = state.normalized !== originalValue.trim();
   if (!changed) {
-    return (
-      <p className="mt-1.5 text-[11px] text-[rgb(var(--muted))]">
-        Ready to save.
-      </p>
-    );
+    return <p className="mt-1.5 text-[11px] text-[rgb(var(--muted))]">Ready to save.</p>;
   }
   return (
     <p className="mt-1.5 text-[11px] text-[rgb(var(--muted))]">
       Will be saved as{' '}
-      <code className="font-mono text-[rgb(var(--foreground))]">
-        {state.normalized}
-      </code>
-      .
+      <code className="font-mono text-[rgb(var(--foreground))]">{state.normalized}</code>.
     </p>
   );
 }
@@ -2223,7 +2163,7 @@ function FormField({
 }) {
   return (
     <div>
-      <label className="block text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))] mb-2">
+      <label className="mb-2 block text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
         {label}
       </label>
       {children}
@@ -2253,7 +2193,7 @@ function Picker({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         disabled={disabled}
-        className="w-full appearance-none px-3 py-2 pr-9 bg-[rgb(var(--background))] border border-[rgb(var(--border))] rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        className="focus:ring-primary-500 focus:border-primary-500 w-full appearance-none rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 pr-9 text-sm focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-50"
         data-testid={testId}
       >
         <option value="">{placeholder}</option>
@@ -2264,7 +2204,7 @@ function Picker({
           </option>
         ))}
       </select>
-      <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-[rgb(var(--muted))] pointer-events-none" />
+      <ChevronDown className="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[rgb(var(--muted))]" />
     </div>
   );
 }
@@ -2284,11 +2224,11 @@ function EmptyState({
 }) {
   if (hasFilter && hasAny) {
     return (
-      <Card className="max-w-2xl mx-auto">
+      <Card className="mx-auto max-w-2xl">
         <CardContent className="flex flex-col items-center justify-center py-16">
-          <Search className="h-16 w-16 text-[rgb(var(--muted))] mb-4" />
-          <h3 className="text-lg font-medium mb-2">No workspaces match</h3>
-          <p className="text-sm text-[rgb(var(--muted))] text-center max-w-md">
+          <Search className="mb-4 h-16 w-16 text-[rgb(var(--muted))]" />
+          <h3 className="mb-2 text-lg font-medium">No workspaces match</h3>
+          <p className="max-w-md text-center text-sm text-[rgb(var(--muted))]">
             Try adjusting the search or filter.
           </p>
         </CardContent>
@@ -2296,19 +2236,18 @@ function EmptyState({
     );
   }
   return (
-    <Card className="max-w-2xl mx-auto">
+    <Card className="mx-auto max-w-2xl">
       <CardContent className="flex flex-col items-center justify-center py-16">
-        <div className="h-16 w-16 rounded-full bg-primary-50 dark:bg-primary-900/20 flex items-center justify-center mb-4">
-          <Radio className="h-8 w-8 text-primary-500" />
+        <div className="bg-primary-50 dark:bg-primary-900/20 mb-4 flex h-16 w-16 items-center justify-center rounded-full">
+          <Radio className="text-primary-500 h-8 w-8" />
         </div>
-        <h3 className="text-lg font-medium mb-2">No folders mapped yet</h3>
-        <p className="text-sm text-[rgb(var(--muted))] text-center max-w-md mb-6">
-          When you open a folder in a connected app, it shows up here so you can
-          choose its tools. You can also map a folder ahead of time — add one
-          now to get started.
+        <h3 className="mb-2 text-lg font-medium">No folders mapped yet</h3>
+        <p className="mb-6 max-w-md text-center text-sm text-[rgb(var(--muted))]">
+          When you open a folder in a connected app, it shows up here so you can choose its tools.
+          You can also map a folder ahead of time — add one now to get started.
         </p>
         <Button variant="primary" onClick={onCreate}>
-          <Plus className="h-4 w-4 mr-2" />
+          <Plus className="mr-2 h-4 w-4" />
           Add a mapping
         </Button>
       </CardContent>

--- a/apps/desktop/src/lib/api/gateway.ts
+++ b/apps/desktop/src/lib/api/gateway.ts
@@ -350,6 +350,7 @@ export async function revokeOAuthClientFeatureSet(
 export interface RegisteredApiKeyClient {
   clientId: string;
   clientName: string;
+  lockedSpaceId: string | null;
   /** The full key — shown once; afterwards only its hash is kept. */
   apiKey: string;
   keyPrefix: string;
@@ -366,11 +367,14 @@ export interface ApiKeyInfo {
 }
 
 /**
- * Register a pre-approved client authenticated by an API key. The returned key
- * is shown once and never retrievable again.
+ * Register a pre-approved client authenticated by an API key, optionally locked
+ * to a space. The returned key is shown once and never retrievable again.
  */
-export async function registerApiKeyClient(name: string): Promise<RegisteredApiKeyClient> {
-  return invoke('register_api_key_client', { name });
+export async function registerApiKeyClient(
+  name: string,
+  lockedSpaceId?: string | null
+): Promise<RegisteredApiKeyClient> {
+  return invoke('register_api_key_client', { name, lockedSpaceId: lockedSpaceId ?? null });
 }
 
 /** Issue an additional API key for an existing client (rotation). Shown once. */

--- a/apps/desktop/src/lib/api/workspaceBindings.ts
+++ b/apps/desktop/src/lib/api/workspaceBindings.ts
@@ -10,6 +10,8 @@ import { invoke } from '@tauri-apps/api/core';
 export interface WorkspaceBinding {
   id: string;
   workspace_root: string;
+  /** `path` (a normalized folder) or `id` (an arbitrary exact-match key). */
+  binding_type: 'path' | 'id';
   space_id: string;
   /**
    * Non-empty by construction. Order is the operator-chosen rendering
@@ -26,6 +28,8 @@ export interface WorkspaceBindingInput {
   workspace_root: string;
   space_id: string;
   feature_set_ids: string[];
+  /** `path` (default — folder, normalized) or `id` (verbatim exact-match key). */
+  binding_type?: 'path' | 'id';
 }
 
 /** List every binding (sorted by workspace_root). */
@@ -69,9 +73,7 @@ export async function validateWorkspaceRoot(path: string): Promise<string> {
 }
 
 /** List bindings whose target Space is the given one. */
-export async function listWorkspaceBindingsForSpace(
-  spaceId: string
-): Promise<WorkspaceBinding[]> {
+export async function listWorkspaceBindingsForSpace(spaceId: string): Promise<WorkspaceBinding[]> {
   return invoke('list_workspace_bindings_for_space', { spaceId });
 }
 

--- a/crates/mcpmux-core/src/domain/mod.rs
+++ b/crates/mcpmux-core/src/domain/mod.rs
@@ -39,5 +39,5 @@ pub use server_log::*;
 pub use space::*;
 pub use workspace_binding::{
     longest_matching_base, normalize_workspace_root, path_is_within, validate_workspace_root,
-    WorkspaceBinding, WorkspaceRootValidation,
+    BindingType, WorkspaceBinding, WorkspaceRootValidation,
 };

--- a/crates/mcpmux-core/src/domain/workspace_binding.rs
+++ b/crates/mcpmux-core/src/domain/workspace_binding.rs
@@ -25,6 +25,38 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// How a binding's `workspace_root` key is matched against a request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum BindingType {
+    /// A normalized absolute folder path (the original behaviour). Matched
+    /// case-/separator-insensitively via [`normalize_workspace_root`].
+    #[default]
+    Path,
+    /// An arbitrary exact-match string — a client id, machine name, or any
+    /// label a headless/remote client sends in `X-Mcpmux-Workspace`. Matched
+    /// verbatim (no path normalization).
+    Id,
+}
+
+impl BindingType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BindingType::Path => "path",
+            BindingType::Id => "id",
+        }
+    }
+
+    /// Parse from storage; unknown values fall back to `Path` (the default for
+    /// pre-`binding_type` rows).
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "id" => BindingType::Id,
+            _ => BindingType::Path,
+        }
+    }
+}
+
 /// A binding between a normalized workspace root and the FeatureSet(s) it
 /// resolves to. `feature_set_ids` MAY be empty — an empty list is a valid
 /// "no Space tools" mapping (the folder still routes to this Space; built-in
@@ -33,6 +65,8 @@ use uuid::Uuid;
 pub struct WorkspaceBinding {
     pub id: Uuid,
     pub workspace_root: String,
+    /// Whether `workspace_root` is a filesystem path or an arbitrary id key.
+    pub binding_type: BindingType,
     pub space_id: Uuid,
     /// Order matters for UI rendering only — the resolver treats them as
     /// a set. Stored in the `workspace_binding_feature_sets` junction
@@ -63,10 +97,21 @@ impl WorkspaceBinding {
         Self {
             id: Uuid::new_v4(),
             workspace_root: workspace_root.into(),
+            binding_type: BindingType::Path,
             space_id,
             feature_set_ids,
             created_at: now,
             updated_at: now,
+        }
+    }
+
+    /// Construct an **id-keyed** binding: `key` is matched verbatim (exact
+    /// string, no path normalization) rather than as a folder. Used to route
+    /// headless/remote clients by a client id or an arbitrary label.
+    pub fn new_id(key: impl Into<String>, space_id: Uuid, feature_set_ids: Vec<String>) -> Self {
+        Self {
+            binding_type: BindingType::Id,
+            ..Self::new_multi(key, space_id, feature_set_ids)
         }
     }
 }

--- a/crates/mcpmux-core/src/repository/mod.rs
+++ b/crates/mcpmux-core/src/repository/mod.rs
@@ -276,6 +276,12 @@ pub trait WorkspaceBindingRepository: Send + Sync {
         &self,
         candidate_roots: &[String],
     ) -> RepoResult<Option<WorkspaceBinding>>;
+
+    /// Resolve an **id-keyed** binding by exact-string match (no path
+    /// normalization). Used to route headless/remote clients by a client id or
+    /// an arbitrary label sent in `X-Mcpmux-Workspace`. Only `BindingType::Id`
+    /// bindings are considered, so a folder path can never collide with a label.
+    async fn find_by_id_key(&self, key: &str) -> RepoResult<Option<WorkspaceBinding>>;
 }
 
 /// Credential repository trait (local-only, never synced)

--- a/crates/mcpmux-gateway/src/services/feature_set_resolver.rs
+++ b/crates/mcpmux-gateway/src/services/feature_set_resolver.rs
@@ -95,7 +95,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use mcpmux_core::{
-    FeatureSetRepository, SpaceBaseDirRepository, SpaceRepository, WorkspaceBindingRepository,
+    FeatureSetRepository, SpaceBaseDirRepository, SpaceRepository, WorkspaceBinding,
+    WorkspaceBindingRepository,
 };
 use mcpmux_storage::InboundClientRepository;
 use serde::Serialize;
@@ -281,6 +282,65 @@ impl FeatureSetResolverService {
         })
     }
 
+    /// Resolve a binding from header/root candidate keys: a **path** binding
+    /// (exact normalized match) or, failing that, an **id** binding (exact
+    /// verbatim match — a client id or arbitrary label). First hit wins. Path
+    /// and id bindings live in disjoint namespaces in the repo, so this never
+    /// double-matches.
+    async fn mapping_binding_for_roots(
+        &self,
+        roots: &[String],
+    ) -> Result<Option<WorkspaceBinding>> {
+        if let Some(b) = self.binding_repo.find_exact_for_roots(roots).await? {
+            return Ok(Some(b));
+        }
+        for r in roots {
+            if let Some(b) = self.binding_repo.find_by_id_key(r).await? {
+                return Ok(Some(b));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Resolve a client locked to Space `locked`. The Space is fixed to
+    /// `locked`; the header/roots may still pick the FeatureSet, but only when
+    /// their binding lives in `locked`. A header whose binding resolves to a
+    /// different Space — or no header at all — falls back to `locked`'s Starter.
+    /// A locked client never touches the roots-pending or client-grant tiers.
+    async fn resolve_locked(
+        &self,
+        session_id: Option<&str>,
+        locked: Uuid,
+    ) -> Result<ResolvedFeatureSet> {
+        if let Some(sid) = session_id {
+            if let Some(roots) = self.session_roots.get(sid) {
+                if !roots.is_empty() {
+                    if let Some(binding) = self.mapping_binding_for_roots(&roots).await? {
+                        if binding.space_id == locked {
+                            debug!(
+                                %locked,
+                                workspace_root = %binding.workspace_root,
+                                "[FeatureSetResolver] locked client — header binding within locked Space",
+                            );
+                            return Ok(ResolvedFeatureSet {
+                                feature_set_ids: binding.feature_set_ids,
+                                space_id: Some(locked),
+                                source: ResolutionSource::WorkspaceBinding,
+                            });
+                        }
+                        debug!(
+                            %locked,
+                            binding_space = %binding.space_id,
+                            "[FeatureSetResolver] locked client — header binding in a different Space; ignored",
+                        );
+                    }
+                }
+            }
+        }
+        // No header, or its binding is outside the locked Space → locked Starter.
+        self.default_fallback(locked).await
+    }
+
     /// Borrow the session-roots registry. The notifier uses this to GC
     /// dead sessions out of the registry when reaping the corresponding
     /// peer entries — keeping both stores in sync.
@@ -310,6 +370,23 @@ impl FeatureSetResolverService {
                 });
             }
         };
+
+        // Lock-confine: a client locked to Space L only ever resolves to L. The
+        // header/roots may still pick a FeatureSet *within* L; a binding that
+        // resolves to a different Space — or no header — yields L's Starter.
+        // Bypasses the roots-pending and grant tiers entirely.
+        if let Some(cid) = client_id {
+            if let Some(locked) = self.client_repo.get_locked_space(cid).await? {
+                match locked.parse::<Uuid>() {
+                    Ok(locked_uuid) => return self.resolve_locked(session_id, locked_uuid).await,
+                    Err(e) => warn!(
+                        client_id = %cid,
+                        locked_space = %locked,
+                        "[FeatureSetResolver] client locked to unparseable space id: {e}",
+                    ),
+                }
+            }
+        }
 
         // Tier 1 / 1b / 1c — branches on roots-capable + roots-arrived state.
         if let Some(sid) = session_id {
@@ -345,11 +422,9 @@ impl FeatureSetResolverService {
             // (no ancestor inheritance).
             if has_roots {
                 let reported_roots = roots.expect("has_roots implies Some");
-                if let Some(binding) = self
-                    .binding_repo
-                    .find_exact_for_roots(&reported_roots)
-                    .await?
-                {
+                // Exact binding match: a path binding (normalized folder) or an
+                // id binding (verbatim label / client-id sent in the header).
+                if let Some(binding) = self.mapping_binding_for_roots(&reported_roots).await? {
                     debug!(
                         workspace_root = %binding.workspace_root,
                         space_id = %binding.space_id,
@@ -433,6 +508,23 @@ impl FeatureSetResolverService {
         // (the desktop UI's preview HTTP path lands here too). Consult the
         // per-client grant table.
         if let Some(cid) = client_id {
+            // clientId-keyed mapping (auto-created for API-key clients): when no
+            // header/roots selected a binding above, route by the client's own
+            // id. Editor clients have no such binding and fall through to grants.
+            if let Some(binding) = self.binding_repo.find_by_id_key(cid).await? {
+                debug!(
+                    client_id = %cid,
+                    workspace_root = %binding.workspace_root,
+                    space_id = %binding.space_id,
+                    "[FeatureSetResolver] resolved via clientId mapping",
+                );
+                return Ok(ResolvedFeatureSet {
+                    feature_set_ids: binding.feature_set_ids,
+                    space_id: Some(binding.space_id),
+                    source: ResolutionSource::WorkspaceBinding,
+                });
+            }
+
             // Propagate storage errors instead of treating them as "no
             // grants": a transient DB failure must surface as a request
             // error, not a silent deny (which would also record a `None`

--- a/crates/mcpmux-gateway/src/services/feature_set_resolver.rs
+++ b/crates/mcpmux-gateway/src/services/feature_set_resolver.rs
@@ -303,13 +303,15 @@ impl FeatureSetResolverService {
     }
 
     /// Resolve a client locked to Space `locked`. The Space is fixed to
-    /// `locked`; the header/roots may still pick the FeatureSet, but only when
-    /// their binding lives in `locked`. A header whose binding resolves to a
-    /// different Space — or no header at all — falls back to `locked`'s Starter.
-    /// A locked client never touches the roots-pending or client-grant tiers.
+    /// `locked`; the header/roots — or the client's own retargeted clientId
+    /// mapping — may still pick the FeatureSet, but only when that binding lives
+    /// in `locked`. A binding that resolves to a different Space (or no binding
+    /// at all) falls back to `locked`'s Starter. A locked client never touches
+    /// the roots-pending or client-grant tiers.
     async fn resolve_locked(
         &self,
         session_id: Option<&str>,
+        client_id: Option<&str>,
         locked: Uuid,
     ) -> Result<ResolvedFeatureSet> {
         if let Some(sid) = session_id {
@@ -337,7 +339,35 @@ impl FeatureSetResolverService {
                 }
             }
         }
-        // No header, or its binding is outside the locked Space → locked Starter.
+        // A locked client may still have its clientId-keyed `id` mapping
+        // retargeted from the Mapping tab. Honor that mapping's FeatureSet — but
+        // only when it stays within the locked Space, preserving
+        // lock-confinement. A mapping pointing out of the Space (or none) falls
+        // through to the locked Starter.
+        if let Some(cid) = client_id {
+            if let Some(binding) = self.binding_repo.find_by_id_key(cid).await? {
+                if binding.space_id == locked {
+                    debug!(
+                        %locked,
+                        client_id = %cid,
+                        "[FeatureSetResolver] locked client — clientId mapping within locked Space",
+                    );
+                    return Ok(ResolvedFeatureSet {
+                        feature_set_ids: binding.feature_set_ids,
+                        space_id: Some(locked),
+                        source: ResolutionSource::WorkspaceBinding,
+                    });
+                }
+                debug!(
+                    %locked,
+                    client_id = %cid,
+                    binding_space = %binding.space_id,
+                    "[FeatureSetResolver] locked client — clientId mapping in a different Space; ignored",
+                );
+            }
+        }
+
+        // No header/mapping within the locked Space → locked Starter.
         self.default_fallback(locked).await
     }
 
@@ -378,7 +408,11 @@ impl FeatureSetResolverService {
         if let Some(cid) = client_id {
             if let Some(locked) = self.client_repo.get_locked_space(cid).await? {
                 match locked.parse::<Uuid>() {
-                    Ok(locked_uuid) => return self.resolve_locked(session_id, locked_uuid).await,
+                    Ok(locked_uuid) => {
+                        return self
+                            .resolve_locked(session_id, client_id, locked_uuid)
+                            .await
+                    }
                     Err(e) => warn!(
                         client_id = %cid,
                         locked_space = %locked,

--- a/crates/mcpmux-storage/src/database.rs
+++ b/crates/mcpmux-storage/src/database.rs
@@ -133,6 +133,16 @@ const MIGRATIONS: &[Migration] = &[
         name: "inbound_client_api_keys",
         sql: include_str!("migrations/020_inbound_client_api_keys.sql"),
     },
+    Migration {
+        version: 21,
+        name: "binding_type",
+        sql: include_str!("migrations/021_binding_type.sql"),
+    },
+    Migration {
+        version: 22,
+        name: "inbound_client_locked_space",
+        sql: include_str!("migrations/022_inbound_client_locked_space.sql"),
+    },
 ];
 
 /// SQLite database wrapper.

--- a/crates/mcpmux-storage/src/migrations/021_binding_type.sql
+++ b/crates/mcpmux-storage/src/migrations/021_binding_type.sql
@@ -1,0 +1,11 @@
+-- Migration 021: workspace binding type (path vs id)
+--
+-- Generalizes mappings beyond filesystem folders. A binding's `workspace_root`
+-- is now a routing KEY that is either:
+--   * 'path' — a normalized absolute folder path (the original behaviour), or
+--   * 'id'   — an arbitrary exact-match string (a client id, machine name, or
+--              any label a headless/remote client sends in X-Mcpmux-Workspace).
+-- Existing rows are folder paths, so they default to 'path' (backward
+-- compatible). Path keys are normalized + case-folded before comparison;
+-- id keys are matched verbatim.
+ALTER TABLE workspace_bindings ADD COLUMN binding_type TEXT NOT NULL DEFAULT 'path';

--- a/crates/mcpmux-storage/src/migrations/022_inbound_client_locked_space.sql
+++ b/crates/mcpmux-storage/src/migrations/022_inbound_client_locked_space.sql
@@ -1,0 +1,9 @@
+-- Migration 022: lock an inbound client to a single Space
+--
+-- An API-key (or any pre-registered) client may be confined to one Space. When
+-- set, the FeatureSet resolver always resolves this client to `locked_space_id`,
+-- ignoring an X-Mcpmux-Workspace header that points at a *different* Space (the
+-- header may still select a FeatureSet *within* the locked Space). NULL =
+-- unlocked (the default) — the client routes freely by header / clientId
+-- mapping / default Space.
+ALTER TABLE inbound_clients ADD COLUMN locked_space_id TEXT;

--- a/crates/mcpmux-storage/src/repositories/inbound_client_repository.rs
+++ b/crates/mcpmux-storage/src/repositories/inbound_client_repository.rs
@@ -707,6 +707,36 @@ impl InboundClientRepository {
         Ok(())
     }
 
+    /// Set (or clear, with `None`) the Space a client is locked to. A locked
+    /// client is confined to that Space during resolution (see the gateway
+    /// FeatureSet resolver).
+    pub async fn set_locked_space(&self, client_id: &str, space_id: Option<&str>) -> Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let db = self.db.lock().await;
+        let conn = db.connection();
+        conn.execute(
+            "UPDATE inbound_clients SET locked_space_id = ?1, updated_at = ?2 WHERE client_id = ?3",
+            params![space_id, now, client_id],
+        )?;
+        Ok(())
+    }
+
+    /// The Space a client is locked to, if any.
+    pub async fn get_locked_space(&self, client_id: &str) -> Result<Option<String>> {
+        let db = self.db.lock().await;
+        let conn = db.connection();
+        let result = conn.query_row(
+            "SELECT locked_space_id FROM inbound_clients WHERE client_id = ?1",
+            params![client_id],
+            |r| r.get::<_, Option<String>>(0),
+        );
+        match result {
+            Ok(v) => Ok(v),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     /// Save a token record
     pub async fn save_token(&self, record: &TokenRecord) -> Result<()> {
         let db = self.db.lock().await;

--- a/crates/mcpmux-storage/src/repositories/workspace_binding_repository.rs
+++ b/crates/mcpmux-storage/src/repositories/workspace_binding_repository.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use mcpmux_core::{WorkspaceBinding, WorkspaceBindingRepository};
+use mcpmux_core::{BindingType, WorkspaceBinding, WorkspaceBindingRepository};
 use rusqlite::params;
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -67,10 +67,12 @@ impl SqliteWorkspaceBindingRepository {
         let space_id_str: String = row.get(2)?;
         let created_at: String = row.get(3)?;
         let updated_at: String = row.get(4)?;
+        let binding_type: String = row.get(5)?;
 
         Ok(WorkspaceBinding {
             id: id_str.parse().unwrap_or_else(|_| Uuid::new_v4()),
             workspace_root,
+            binding_type: BindingType::parse(&binding_type),
             space_id: space_id_str.parse().unwrap_or_else(|_| Uuid::nil()),
             feature_set_ids: Vec::new(), // filled in by caller
             created_at: Self::parse_datetime(&created_at),
@@ -149,7 +151,8 @@ impl SqliteWorkspaceBindingRepository {
         Ok(())
     }
 
-    const SELECT_COLS: &'static str = "id, workspace_root, space_id, created_at, updated_at";
+    const SELECT_COLS: &'static str =
+        "id, workspace_root, space_id, created_at, updated_at, binding_type";
 
     /// Fetch bindings + their FeatureSet lists in two queries.
     /// `where_clause` is appended to the binding SELECT (use `""` for none);
@@ -221,14 +224,15 @@ impl WorkspaceBindingRepository for SqliteWorkspaceBindingRepository {
         let tx = conn.unchecked_transaction()?;
         tx.execute(
             "INSERT INTO workspace_bindings
-                (id, workspace_root, space_id, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
+                (id, workspace_root, space_id, created_at, updated_at, binding_type)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
                 binding.id.to_string(),
                 binding.workspace_root,
                 binding.space_id.to_string(),
                 binding.created_at.to_rfc3339(),
                 binding.updated_at.to_rfc3339(),
+                binding.binding_type.as_str(),
             ],
         )?;
         Self::rewrite_fs_for_binding(&tx, &binding.id.to_string(), &binding.feature_set_ids)?;
@@ -248,13 +252,14 @@ impl WorkspaceBindingRepository for SqliteWorkspaceBindingRepository {
         let tx = conn.unchecked_transaction()?;
         let rows_affected = tx.execute(
             "UPDATE workspace_bindings
-             SET workspace_root = ?2, space_id = ?3, updated_at = ?4
+             SET workspace_root = ?2, space_id = ?3, updated_at = ?4, binding_type = ?5
              WHERE id = ?1",
             params![
                 binding.id.to_string(),
                 binding.workspace_root,
                 binding.space_id.to_string(),
                 binding.updated_at.to_rfc3339(),
+                binding.binding_type.as_str(),
             ],
         )?;
 
@@ -292,13 +297,28 @@ impl WorkspaceBindingRepository for SqliteWorkspaceBindingRepository {
 
         let bindings = self.list().await?;
         // Exact match only — no ancestor/prefix inheritance. A folder resolves
-        // to a binding for THAT exact root, or to nothing.
+        // to a binding for THAT exact root, or to nothing. Only PATH bindings
+        // participate here; id-keyed bindings are matched via `find_by_id_key`
+        // so a folder root can never collide with an arbitrary id label.
         for root in candidate_roots {
-            if let Some(b) = bindings.iter().find(|b| &b.workspace_root == root) {
+            if let Some(b) = bindings
+                .iter()
+                .find(|b| b.binding_type == BindingType::Path && &b.workspace_root == root)
+            {
                 return Ok(Some(b.clone()));
             }
         }
         Ok(None)
+    }
+
+    async fn find_by_id_key(&self, key: &str) -> Result<Option<WorkspaceBinding>> {
+        if key.is_empty() {
+            return Ok(None);
+        }
+        let bindings = self.list().await?;
+        Ok(bindings
+            .into_iter()
+            .find(|b| b.binding_type == BindingType::Id && b.workspace_root == key))
     }
 }
 
@@ -505,5 +525,46 @@ mod tests {
             .unwrap()
             .expect("exact match");
         assert_eq!(hit.workspace_root, exact);
+    }
+
+    #[tokio::test]
+    async fn test_id_binding_matches_by_exact_key_not_as_path() {
+        // An id-keyed binding is matched verbatim via find_by_id_key and is
+        // invisible to the path-based find_exact_for_roots (and vice versa) so a
+        // folder root and an arbitrary id label can never collide.
+        let (repo, space_id, fs_id) = fixture().await;
+        let key = "mcp_abc12345"; // e.g. a client id
+        let binding = WorkspaceBinding::new_id(key, space_id, vec![fs_id.clone()]);
+        repo.create(&binding).await.unwrap();
+
+        // Exact id lookup hits and round-trips the type + key.
+        let got = repo.find_by_id_key(key).await.unwrap().expect("id match");
+        assert_eq!(got.binding_type, BindingType::Id);
+        assert_eq!(got.workspace_root, key);
+        assert_eq!(got.feature_set_ids, vec![fs_id.clone()]);
+
+        // The path resolver ignores id bindings.
+        assert!(repo
+            .find_exact_for_roots(&[key.to_string()])
+            .await
+            .unwrap()
+            .is_none());
+
+        // A path binding is invisible to the id lookup, but visible to the
+        // path resolver.
+        let path_root = if cfg!(windows) {
+            "d:\\idtest"
+        } else {
+            "/idtest"
+        };
+        repo.create(&WorkspaceBinding::new(path_root, space_id, fs_id))
+            .await
+            .unwrap();
+        assert!(repo.find_by_id_key(path_root).await.unwrap().is_none());
+        assert!(repo
+            .find_exact_for_roots(&[path_root.to_string()])
+            .await
+            .unwrap()
+            .is_some());
     }
 }

--- a/tests/rust/tests/database/migrations.rs
+++ b/tests/rust/tests/database/migrations.rs
@@ -151,3 +151,82 @@ fn test_018_rewrites_stale_starter_description_only() {
         "operator-customized copy must be preserved"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Upgrade path — applying NEW migrations to an EXISTING (older) on-disk DB.
+//
+// Every other test here uses a FRESH in-memory DB, where all migrations run at
+// once — so they never catch a migration that fails to apply when a real user
+// opens a database created by a previous release. These two do.
+// ---------------------------------------------------------------------------
+
+fn table_exists(db: &Database, name: &str) -> bool {
+    db.connection()
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name=?1",
+            [name],
+            |r| r.get::<_, bool>(0),
+        )
+        .unwrap_or(false)
+}
+
+fn column_exists(db: &Database, table: &str, column: &str) -> bool {
+    let sql = format!("SELECT COUNT(*) > 0 FROM pragma_table_info('{table}') WHERE name=?1");
+    db.connection()
+        .query_row(&sql, [column], |r| r.get::<_, bool>(0))
+        .unwrap_or(false)
+}
+
+#[test]
+fn test_new_schema_objects_exist_after_migration() {
+    // A fresh migrate must produce every object the API-key + mapping features
+    // depend on — a regression guard against a migration being dropped or broken.
+    let db = Database::open_in_memory().expect("open");
+    assert!(
+        table_exists(&db, "inbound_client_api_keys"),
+        "migration 020 must create inbound_client_api_keys"
+    );
+    assert!(
+        column_exists(&db, "workspace_bindings", "binding_type"),
+        "migration 021 must add workspace_bindings.binding_type"
+    );
+    assert!(
+        column_exists(&db, "inbound_clients", "locked_space_id"),
+        "migration 022 must add inbound_clients.locked_space_id"
+    );
+}
+
+#[test]
+fn test_pending_migrations_apply_to_an_existing_older_database() {
+    // Reproduce the real upgrade that surfaced "no such table:
+    // inbound_client_api_keys" in the field: a DB created before 020/021/022
+    // existed, reopened by a newer build. The pending migrations MUST apply.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("mcpmux.db");
+
+    // 1. Fully migrate, then roll the schema back to a pre-020 state.
+    {
+        let db = Database::open(&path).expect("open");
+        db.connection()
+            .execute_batch(
+                "DELETE FROM schema_migrations WHERE version >= 20;
+                 DROP TABLE IF EXISTS inbound_client_api_keys;
+                 ALTER TABLE workspace_bindings DROP COLUMN binding_type;
+                 ALTER TABLE inbound_clients DROP COLUMN locked_space_id;",
+            )
+            .expect("roll schema back to pre-020");
+        assert!(
+            !table_exists(&db, "inbound_client_api_keys"),
+            "precondition: the rolled-back DB is missing the table"
+        );
+    }
+
+    // 2. Reopen — run_migrations() must re-apply 020/021/022.
+    let db = Database::open(&path).expect("reopen older DB");
+    assert!(
+        table_exists(&db, "inbound_client_api_keys"),
+        "reopening an older DB must re-create inbound_client_api_keys"
+    );
+    assert!(column_exists(&db, "workspace_bindings", "binding_type"));
+    assert!(column_exists(&db, "inbound_clients", "locked_space_id"));
+}

--- a/tests/rust/tests/integration/feature_set_resolver.rs
+++ b/tests/rust/tests/integration/feature_set_resolver.rs
@@ -975,3 +975,75 @@ async fn locked_client_with_no_header_gets_locked_space_starter() {
     assert_eq!(r.source, ResolutionSource::SpaceDefault);
     assert_eq!(r.feature_set_ids, vec![f.starter_fs_id]);
 }
+
+#[tokio::test]
+async fn locked_client_honors_in_space_retargeted_client_id_mapping() {
+    // A locked client with no header: its clientId-keyed mapping was retargeted
+    // (from the auto-created Starter) to another FeatureSet that still lives in
+    // the locked Space. The resolver must honor that mapping — the Space stays
+    // locked, but the operator's FeatureSet choice is respected.
+    let f = Fixture::new().await;
+    f.make_client("locked-4").await;
+    f.client_repo
+        .set_locked_space("locked-4", Some(&f.space_id.to_string()))
+        .await
+        .unwrap();
+    // Retargeted clientId mapping → a non-Starter FS within the locked Space.
+    f.binding_repo
+        .create(&WorkspaceBinding::new_id(
+            "locked-4",
+            f.space_id,
+            vec![f.fs_a_id.clone()],
+        ))
+        .await
+        .unwrap();
+    // No header; explicitly rootless so we reach the clientId tier.
+    f.session_roots.set_roots_capable("s", false);
+    let r = f
+        .resolver
+        .resolve(Some("s"), Some("locked-4"))
+        .await
+        .unwrap();
+    assert_eq!(r.source, ResolutionSource::WorkspaceBinding);
+    assert_eq!(r.space_id, Some(f.space_id));
+    assert_eq!(r.feature_set_ids, vec![f.fs_a_id]);
+}
+
+#[tokio::test]
+async fn locked_client_ignores_out_of_space_client_id_mapping() {
+    // A locked client whose clientId mapping points at a DIFFERENT Space must be
+    // confined to the locked Space: the out-of-Space mapping is ignored and the
+    // client falls back to the locked Space's Starter (lock-confinement holds).
+    let f = Fixture::new().await;
+    f.make_client("locked-5").await;
+    let other_base = if cfg!(windows) {
+        "d:\\elsewhere"
+    } else {
+        "/elsewhere"
+    };
+    let (other_space, other_starter) = f.make_space_with_base_dir("Elsewhere", other_base).await;
+    f.client_repo
+        .set_locked_space("locked-5", Some(&f.space_id.to_string()))
+        .await
+        .unwrap();
+    // clientId mapping points OUT of the locked Space.
+    f.binding_repo
+        .create(&WorkspaceBinding::new_id(
+            "locked-5",
+            other_space,
+            vec![other_starter],
+        ))
+        .await
+        .unwrap();
+    // No header; explicitly rootless so we reach the clientId tier.
+    f.session_roots.set_roots_capable("s", false);
+    let r = f
+        .resolver
+        .resolve(Some("s"), Some("locked-5"))
+        .await
+        .unwrap();
+    // Confined to the locked (default) Space; the foreign mapping is ignored.
+    assert_eq!(r.space_id, Some(f.space_id));
+    assert_eq!(r.source, ResolutionSource::SpaceDefault);
+    assert_eq!(r.feature_set_ids, vec![f.starter_fs_id]);
+}

--- a/tests/rust/tests/integration/feature_set_resolver.rs
+++ b/tests/rust/tests/integration/feature_set_resolver.rs
@@ -808,3 +808,170 @@ async fn pinned_header_root_without_binding_falls_back_to_space_default() {
     assert_eq!(r.feature_set_ids, vec![f.starter_fs_id.clone()]);
     assert_eq!(r.space_id, Some(f.space_id));
 }
+
+// ---------------------------------------------------------------------------
+// Generalized mappings (id-keyed bindings) + clientId routing + lock-confine
+// (P2). Precedence (unlocked): header > clientId-binding > Space default.
+// Locked: Space is ALWAYS the locked one; the header only picks the FeatureSet
+// when its binding lives in that Space, else the locked Space's Starter.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn id_binding_routes_by_header_value() {
+    // A header that is an arbitrary label (not a folder) routes via an id-keyed
+    // binding: the pinned header shadows roots and matches the id verbatim.
+    let f = Fixture::new().await;
+    f.binding_repo
+        .create(&WorkspaceBinding::new_id(
+            "team-x",
+            f.space_id,
+            vec![f.fs_a_id.clone()],
+        ))
+        .await
+        .unwrap();
+    f.session_roots.set_pinned("s", "team-x");
+    let r = f
+        .resolver
+        .resolve(Some("s"), Some("client-1"))
+        .await
+        .unwrap();
+    assert_eq!(r.source, ResolutionSource::WorkspaceBinding);
+    assert_eq!(r.space_id, Some(f.space_id));
+    assert_eq!(r.feature_set_ids, vec![f.fs_a_id]);
+}
+
+#[tokio::test]
+async fn client_id_binding_routes_when_no_header() {
+    // No header/roots: an unlocked client routes by its own clientId via an
+    // id-binding keyed by the client id (auto-created on registration).
+    let f = Fixture::new().await;
+    f.make_client("mcp_abc").await;
+    f.binding_repo
+        .create(&WorkspaceBinding::new_id(
+            "mcp_abc",
+            f.space_id,
+            vec![f.fs_b_id.clone()],
+        ))
+        .await
+        .unwrap();
+    // Explicitly rootless so we skip the pending grace and reach the clientId tier.
+    f.session_roots.set_roots_capable("s", false);
+    let r = f
+        .resolver
+        .resolve(Some("s"), Some("mcp_abc"))
+        .await
+        .unwrap();
+    assert_eq!(r.source, ResolutionSource::WorkspaceBinding);
+    assert_eq!(r.feature_set_ids, vec![f.fs_b_id]);
+}
+
+#[tokio::test]
+async fn header_beats_client_id_binding_when_both_present() {
+    // Unlocked precedence: an explicit header outranks the clientId binding.
+    let f = Fixture::new().await;
+    f.make_client("mcp_abc").await;
+    f.binding_repo
+        .create(&WorkspaceBinding::new_id(
+            "mcp_abc",
+            f.space_id,
+            vec![f.fs_b_id.clone()],
+        ))
+        .await
+        .unwrap();
+    f.binding_repo
+        .create(&WorkspaceBinding::new_id(
+            "team-x",
+            f.space_id,
+            vec![f.fs_a_id.clone()],
+        ))
+        .await
+        .unwrap();
+    f.session_roots.set_pinned("s", "team-x");
+    let r = f
+        .resolver
+        .resolve(Some("s"), Some("mcp_abc"))
+        .await
+        .unwrap();
+    assert_eq!(r.feature_set_ids, vec![f.fs_a_id]); // header's FS, not clientId's
+}
+
+#[tokio::test]
+async fn locked_client_uses_header_fs_when_binding_is_in_locked_space() {
+    // A locked client whose header binding lives IN the locked Space uses that
+    // binding's FeatureSet — the Space stays locked, the FeatureSet is selectable.
+    let f = Fixture::new().await;
+    f.make_client("locked-2").await;
+    f.client_repo
+        .set_locked_space("locked-2", Some(&f.space_id.to_string()))
+        .await
+        .unwrap();
+    f.binding_repo
+        .create(&WorkspaceBinding::new_id(
+            "inhouse",
+            f.space_id,
+            vec![f.fs_a_id.clone()],
+        ))
+        .await
+        .unwrap();
+    f.session_roots.set_pinned("s", "inhouse");
+    let r = f
+        .resolver
+        .resolve(Some("s"), Some("locked-2"))
+        .await
+        .unwrap();
+    assert_eq!(r.source, ResolutionSource::WorkspaceBinding);
+    assert_eq!(r.space_id, Some(f.space_id));
+    assert_eq!(r.feature_set_ids, vec![f.fs_a_id]);
+}
+
+#[tokio::test]
+async fn locked_client_ignores_foreign_header_and_uses_locked_starter() {
+    // A client locked to Space L, sending a header whose binding lives in a
+    // DIFFERENT Space, is confined to L and falls back to L's Starter.
+    let f = Fixture::new().await;
+    f.make_client("locked-1").await;
+    let other_base = if cfg!(windows) { "d:\\other" } else { "/other" };
+    let (other_space, other_starter) = f.make_space_with_base_dir("Other", other_base).await;
+    f.client_repo
+        .set_locked_space("locked-1", Some(&f.space_id.to_string()))
+        .await
+        .unwrap();
+    // Header binding points at the OTHER space.
+    f.binding_repo
+        .create(&WorkspaceBinding::new_id(
+            "foreign",
+            other_space,
+            vec![other_starter],
+        ))
+        .await
+        .unwrap();
+    f.session_roots.set_pinned("s", "foreign");
+    let r = f
+        .resolver
+        .resolve(Some("s"), Some("locked-1"))
+        .await
+        .unwrap();
+    // Confined to the locked (default) Space; the foreign header is ignored.
+    assert_eq!(r.space_id, Some(f.space_id));
+    assert_eq!(r.source, ResolutionSource::SpaceDefault);
+    assert_eq!(r.feature_set_ids, vec![f.starter_fs_id]);
+}
+
+#[tokio::test]
+async fn locked_client_with_no_header_gets_locked_space_starter() {
+    let f = Fixture::new().await;
+    f.make_client("locked-3").await;
+    f.client_repo
+        .set_locked_space("locked-3", Some(&f.space_id.to_string()))
+        .await
+        .unwrap();
+    f.session_roots.set_roots_capable("s", false);
+    let r = f
+        .resolver
+        .resolve(Some("s"), Some("locked-3"))
+        .await
+        .unwrap();
+    assert_eq!(r.space_id, Some(f.space_id));
+    assert_eq!(r.source, ResolutionSource::SpaceDefault);
+    assert_eq!(r.feature_set_ids, vec![f.starter_fs_id]);
+}

--- a/tests/ts/components/WorkspaceSetupWizard.test.tsx
+++ b/tests/ts/components/WorkspaceSetupWizard.test.tsx
@@ -81,6 +81,7 @@ describe('WorkspaceSetupWizard', () => {
       workspace_root: '/proj/app',
       space_id: 's1',
       feature_set_ids: ['fs_starter'],
+      binding_type: 'path',
     });
     // The parent navigates to the new mapping's inspector (effective features);
     // the wizard itself does not close.


### PR DESCRIPTION
## P2 of 3 — stacked on #201 (P1)

> **Base = `p1-auth-api-key`.** Review/merge **after #201**. GitHub will re-target this to `main` once P1 merges.

Adds **generalized client → Space/FeatureSet mappings** and **lock-confinement**, building on P1's API-key auth.
Cleanly separates **authentication** (API key → `clientId`) from **mapping** (which Space/FeatureSet a client gets).

### What's in P2
- **storage**: migration `021` (`binding_type` = `path` | `id`), migration `022` (`locked_space_id`), `find_by_id_key`.
- **resolver** (`feature_set_resolver.rs`): clientId-binding tier + **lock-confine** — a locked client is always
  confined to its locked Space; the header only selects the FeatureSet within it.
- **register**: auto-map API-key clients (clientId binding) + `binding_type` in the TS API.
- **UI**: create/edit id-mappings in the Mapping tab; id-mapping creation reachable via the create wizard.
- Restores the `locked_space` wiring deferred from P1 (Strategy Y) — verified **byte-identical** to the original
  feature branch for all shared files.

### Resolution precedence
- **Locked** client → Space is **always** the locked one; header only picks the FeatureSet within it
  (foreign-Space header → locked Starter).
- **Unlocked** → header (path/id) > clientId binding > default-Space Starter.

### Fix included (QA finding)
A locked client's **retargeted clientId mapping was silently ignored** (resolver always served the locked
Starter even after an operator retargeted it in the Mapping tab). `resolve_locked` now consults
`find_by_id_key(client_id)` and honors that FeatureSet **only when it stays in the locked Space**
(out-of-Space → locked Starter; lock-confinement preserved). + 2 new resolver tests.

### Test plan
- `cargo nextest run -p tests -E 'test(feature_set_resolver) + test(migrations)'` → 41 pass, incl. the 2 new
  lock tests and the upgrade-on-existing-older-DB migration test.
- `pnpm test:ts` → 224 pass; `cargo check --workspace` + `pnpm typecheck` clean; pre-commit green.

https://claude.ai/code/session_016tTnYSMp9LQ8dyCdcdGN4Z
