### PR TITLE
chore: correct codecov commit type from fix to chore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ permissions:
   actions: read
   checks: write
   pull-requests: write
-  id-token: write
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This PR corrects the commit type classification for the OIDC token permission change. The original PR #208 was labeled as a 'fix' but it should be a 'chore' since it's a CI/CD configuration change, not an application bug fix. 

Changes:
- Revert the incorrectly labeled 'fix:' commit
- Re-apply the same change with the correct 'chore:' prefix

This ensures the release notes properly categorize this as maintenance work.