### PR TITLE
fix(gateway): restore disabled auth on auto-start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ permissions:
   actions: read
   checks: write
   pull-requests: write
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+

--- a/apps/desktop/src-tauri/src/commands/gateway.rs
+++ b/apps/desktop/src-tauri/src/commands/gateway.rs
@@ -217,6 +217,22 @@ pub(crate) async fn load_network_access(app_state: &AppState) -> bool {
     load_network_access_from_repo(&app_state.settings_repository).await
 }
 
+pub(crate) async fn load_gateway_auth_disabled_from_repo(
+    settings_repository: &Arc<dyn mcpmux_core::AppSettingsRepository>,
+) -> bool {
+    settings_repository
+        .get(GATEWAY_AUTH_DISABLED_KEY)
+        .await
+        .ok()
+        .flatten()
+        .map(|value| value == "true")
+        .unwrap_or(false)
+}
+
+pub(crate) async fn load_gateway_auth_disabled(app_state: &AppState) -> bool {
+    load_gateway_auth_disabled_from_repo(&app_state.settings_repository).await
+}
+
 pub(crate) fn advertised_base_url(public_base_url: Option<&str>, port: u16) -> String {
     public_base_url
         .map(str::trim)
@@ -1037,18 +1053,8 @@ pub async fn start_gateway(
     // Seed the system-wide inbound-auth toggle into the running gateway from
     // persisted settings (default: auth required). Live changes go through
     // `set_gateway_auth_disabled`.
-    {
-        let disabled = app_state
-            .settings_repository
-            .get(GATEWAY_AUTH_DISABLED_KEY)
-            .await
-            .ok()
-            .flatten()
-            .map(|v| v == "true")
-            .unwrap_or(false);
-        if disabled {
-            gw_state.write().await.set_auth_disabled(true);
-        }
+    if load_gateway_auth_disabled(&app_state).await {
+        gw_state.write().await.set_auth_disabled(true);
     }
 
     // Subscribe to OAuth completions BEFORE spawn so we don't miss early
@@ -2039,5 +2045,39 @@ mod public_base_url_tests {
     fn bind_host_for_maps_network_access_to_address() {
         assert_eq!(super::bind_host_for(false), "127.0.0.1");
         assert_eq!(super::bind_host_for(true), "0.0.0.0");
+    }
+}
+
+#[cfg(test)]
+mod gateway_auth_settings_tests {
+    use super::{load_gateway_auth_disabled_from_repo, GATEWAY_AUTH_DISABLED_KEY};
+    use mcpmux_core::AppSettingsRepository;
+    use mcpmux_storage::{Database, SqliteAppSettingsRepository};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    fn settings_repo() -> Arc<dyn AppSettingsRepository> {
+        let database = Database::open_in_memory().expect("create in-memory database");
+        Arc::new(SqliteAppSettingsRepository::new(Arc::new(Mutex::new(
+            database,
+        ))))
+    }
+
+    #[tokio::test]
+    async fn auth_remains_required_when_disable_setting_is_missing() {
+        let repository = settings_repo();
+
+        assert!(!load_gateway_auth_disabled_from_repo(&repository).await);
+    }
+
+    #[tokio::test]
+    async fn persisted_disable_setting_is_restored_on_gateway_start() {
+        let repository = settings_repo();
+        repository
+            .set(GATEWAY_AUTH_DISABLED_KEY, "true")
+            .await
+            .unwrap();
+
+        assert!(load_gateway_auth_disabled_from_repo(&repository).await);
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -425,6 +425,9 @@ pub fn run() {
                 // devices on the LAN can reach the gateway; loopback-only otherwise.
                 let network_access =
                     crate::commands::gateway::load_network_access_from_repo(&settings_repo).await;
+                let auth_disabled =
+                    crate::commands::gateway::load_gateway_auth_disabled_from_repo(&settings_repo)
+                        .await;
                 let local_url = format!("http://localhost:{}", final_port);
                 info!("Auto-starting gateway on {} (advertising {})", local_url, url);
 
@@ -483,6 +486,10 @@ pub fn run() {
                 // Gateway auto-initializes all services and auto-connects enabled servers
                 let server = mcpmux_gateway::GatewayServer::new(config, dependencies);
                 let gw_inner_state = server.state();
+
+                if auth_disabled {
+                    gw_inner_state.write().await.set_auth_disabled(true);
+                }
 
                 // Get services from gateway
                 let pool_service = server.pool_service();


### PR DESCRIPTION
## Summary

- centralize loading of the persisted inbound-auth setting
- apply the setting to both manual and automatic gateway startup
- add regression coverage for the secure default and persisted disabled state

## Root cause

`start_gateway` restored `gateway.auth_disabled` after creating `GatewayState`, but the desktop auto-start path created the same state without restoring the setting. Relaunching the app therefore reverted a configured no-auth gateway to auth-required until the user toggled the setting again.

## Impact

When **Disable authentication** is enabled, relaunching McpMux now preserves that behavior. A missing setting or repository read failure still defaults to authentication required.

## Validation

- `cargo +1.88.0 fmt --all -- --check`
- `cargo +1.88.0 test -p mcpmux --lib` — 34 passed
- `cargo +1.88.0 clippy -p mcpmux --lib -- -D warnings -A clippy::uninlined_format_args`

The narrow Clippy allowance is for a pre-existing Rust 1.88 lint in `crates/mcpmux-core/build.rs`; the changed files pass with warnings denied.