### PR TITLE
chore: add Claude Code GitHub Actions and Codecov OIDC permission

### DIFF
--- a/.github/actions/install-linux-deps/action.yml
+++ b/.github/actions/install-linux-deps/action.yml
@@ -13,6 +13,16 @@ runs:
   using: composite
   steps:
     # Cache apt packages to avoid re-downloading on every run
+    # The runner image ships an apt index from its build date, and
+    # cache-apt-pkgs-action's own refresh (update_apt_lists_if_stale) is a
+    # no-op outside nektos/act -- it guards on ACT=true. A stale index names
+    # .debs that Ubuntu has since superseded and dropped from the pool, so the
+    # install 404s; the action then caches the empty result instead of failing,
+    # and every later run restores that as a hit and skips installing at all.
+    - name: Refresh apt lists
+      shell: bash
+      run: sudo apt-get update
+
     # Pinned to a SHA: `@latest` is a moving tag, so a broken upstream release
     # (e.g. v1.6.2) would otherwise roll straight into CI unreviewed.
     - name: Cache apt packages (base)

--- a/.github/actions/install-linux-deps/action.yml
+++ b/.github/actions/install-linux-deps/action.yml
@@ -13,18 +13,20 @@ runs:
   using: composite
   steps:
     # Cache apt packages to avoid re-downloading on every run
+    # Pinned to a SHA: `@latest` is a moving tag, so a broken upstream release
+    # (e.g. v1.6.2) would otherwise roll straight into CI unreviewed.
     - name: Cache apt packages (base)
-      uses: awalsh128/cache-apt-pkgs-action@latest
+      uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
       with:
         packages: build-essential pkg-config libglib2.0-dev libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libsecret-1-dev libfuse2
-        version: 1.1
+        version: 1.2
 
     - name: Cache apt packages (E2E)
       if: ${{ inputs.e2e == 'true' }}
-      uses: awalsh128/cache-apt-pkgs-action@latest
+      uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
       with:
         packages: webkit2gtk-driver xvfb gnome-keyring gsettings-desktop-schemas dbus-x11 at-spi2-core libglib2.0-bin libwayland-server0 libwayland-client0
-        version: 1.3
+        version: 1.4
 
     # Compile gsettings schemas (required after restore from cache)
     - name: Compile gsettings schemas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ permissions:
   actions: read
   checks: write
   pull-requests: write
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+


### PR DESCRIPTION
## Summary

Repo tooling only — no application code touched.

- **Claude Code GitHub Actions** — adds `claude.yml` (mention-triggered assistant) and `claude-code-review.yml` (automated PR review).
- **Codecov OIDC** — adds `id-token: write` to CI permissions. Without it `codecov/codecov-action@v5` fails with `Could not fetch an OIDC token`.
- **Fixes CI, which is red on every branch including `main`** — see below.

## The CI breakage

Since ~01:07 today every job on every branch failed, including a Dependabot PR that only bumps an npm package. Root cause was a **poisoned apt cache**: a 6 KB entry (a healthy one is hundreds of MB) sat under key `cache-apt-pkgs_fdcf5a845111e7ece6636e1a64892e8c` scoped to `refs/heads/main`. `awalsh128/cache-apt-pkgs-action` restored it, reported `Cache Size: ~0 MB (6324 B)`, treated it as a hit and **skipped installing `libglib2.0-dev`**. Everything downstream fell over:

- `rust-check` — failed at the glib verification step
- `ts-check` — `pnpm lint` shells into cargo, which can't find `glib-2.0.pc`
- `test-report` — no artifacts from the jobs above

Caches scoped to `main` are readable from every PR branch, so one bad entry poisoned everything.

### Fixes

1. The poisoned caches were **deleted out-of-band** (they'd have been restored on every run regardless of this PR).
2. **Cache `version` bumped** (`1.1`→`1.2`, `1.3`→`1.4`) to rotate the key, so a stale entry under the old key can't come back.
3. **Action pinned to v1.6.3 by SHA.** It was tracking `@latest`, a moving tag — upstream's v1.6.2 is literally titled *"(broken, use v1.6.3)"*, and a future bad release would roll in unreviewed.

## Notes

- All commits use `chore:` so release-please keeps them out of the release notes.
- Follow-ups worth considering, not done here: the repo sits at ~9 GB of the 10 GB cache limit with the large Rust caches scoped to PR refs rather than `main` (so they benefit almost nothing); and `ts-check` passes `verify_glib: false` despite running cargo, which is what turned this into a confusing deep failure instead of a fast, clear one.